### PR TITLE
fix(ci): force frontend image re-pull by removing image before pull (#182)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,23 +46,25 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: ENV_PRODUCTION
           script: |
             cd ~/Diving-O-Club_App
-
-            echo "🧹 Cleaning old Docker data..."
-            sudo docker image prune -af
 
             echo "↪️ Pulling latest changes..."
             git fetch origin main
             git reset --hard origin/main
 
-            echo "🎆 Pulling images from Docker Hub..."
-            cd app
-            sudo docker compose -f docker-compose.production.yml --env-file .env.production pull
-
             echo "🔄 Stopping PRODUCTION containers..."
+            cd app
             sudo docker compose -f docker-compose.production.yml --env-file .env.production down
+
+            echo "🗑️ Removing old frontend image to force re-pull..."
+            sudo docker image rm minifrizz/diving-o-club-frontend:latest || true
+
+            echo "🧹 Cleaning old Docker data..."
+            sudo docker image prune -af
+
+            echo "🎆 Pulling images from Docker Hub..."
+            sudo docker compose -f docker-compose.production.yml --env-file .env.production pull
 
             echo "🚀 Starting PRODUCTION services..."
             sudo docker compose -f docker-compose.production.yml --env-file .env.production up -d

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build and push frontend image
         run: |
-          docker build -t minifrizz/diving-o-club-frontend:staging ./app/frontend
+          docker build --no-cache -t minifrizz/diving-o-club-frontend:staging ./app/frontend
           docker push minifrizz/diving-o-club-frontend:staging
 
       - name: Create .env.staging locally
@@ -59,19 +59,22 @@ jobs:
           script: |
             cd ~/Diving-O-Club_App
 
-            echo "🧹 Cleaning old Docker data..."
-            sudo docker image prune -af
-
             echo "↪️ Pulling latest changes..."
             git fetch origin develop
             git reset --hard origin/develop
 
-            echo "🎆 Pulling images from Docker Hub..."
-            cd app
-            sudo docker compose -f docker-compose.staging.yml --env-file .env.staging pull
-
             echo "🔄 Stopping STAGING containers..."
+            cd app
             sudo docker compose -f docker-compose.staging.yml --env-file .env.staging down
+
+            echo "🗑️ Removing old frontend image to force re-pull..."
+            sudo docker image rm minifrizz/diving-o-club-frontend:staging || true
+
+            echo "🧹 Cleaning old Docker data..."
+            sudo docker image prune -af
+
+            echo "🎆 Pulling images from Docker Hub..."
+            sudo docker compose -f docker-compose.staging.yml --env-file .env.staging pull
 
             echo "🚀 Starting STAGING services..."
             sudo docker compose -f docker-compose.staging.yml --env-file .env.staging up -d


### PR DESCRIPTION
deploy-staging.yml: fix docker pull order — stop containers before removing image and pulling
deploy-staging.yml: add --no-cache on frontend build to force rebuild
deploy-production.yml: fix docker pull order — stop containers before removing image and pulling
deploy-production.yml: remove unused envs parameter on SSH deploy step

Closes #182