### PR TITLE
fix(backend): add city to club search ILIKE query (#186)

### DIFF
--- a/app/backend/src/club/club.service.ts
+++ b/app/backend/src/club/club.service.ts
@@ -13,8 +13,11 @@ export class ClubService {
 
   async search(query: string) {
     return this.clubRepo.find({
-      where: { name: ILike(`%${query}%`) },
-      select: ['idClub', 'name', 'city', 'slug'],
+      where: [
+        { name: ILike(`%${query}%`) },
+        { city: ILike(`%${query}%`) },
+      ],
+      select: ['name', 'city', 'slug'],
     });
   }
 


### PR DESCRIPTION
When a user types a city name (e.g. "Dijon") in the club search field, no results are returned.

The ILIKE query only searches on the name column.

Fix: add city column to the search query using OR condition.