### PR TITLE
feat(membership): club membership request flow

### DIFF
--- a/app/backend/src/membership/membership.controller.ts
+++ b/app/backend/src/membership/membership.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Req, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { MembershipService } from './membership.service';
 
@@ -10,11 +10,8 @@ export class MembershipController {
   @UseGuards(AuthGuard('jwt'))
   async getMyMembership(@Req() req: any) {
     const membership = await this.membershipService.findMyMembership(req.user.idUser);
-
     if (!membership) return null;
-
     const { passwordHash: _, ...safeUser } = membership.user as any;
-
     return {
       ...membership,
       user: safeUser,
@@ -26,5 +23,33 @@ export class MembershipController {
         }),
       },
     };
+  }
+
+  @Get('status/:clubId')
+  @UseGuards(AuthGuard('jwt'))
+  async getStatus(@Param('clubId') clubId: string, @Req() req: any) {
+    return this.membershipService.getStatusForClub(
+      req.user.idUser,
+      parseInt(clubId),
+    );
+  }
+
+  @Post('request/:clubId')
+  @UseGuards(AuthGuard('jwt'))
+  async requestMembership(@Param('clubId') clubId: string, @Req() req: any) {
+    return this.membershipService.requestMembership(
+      req.user.idUser,
+      parseInt(clubId),
+    );
+  }
+
+  @Delete('request/:clubId')
+  @UseGuards(AuthGuard('jwt'))
+  async cancelRequest(@Param('clubId') clubId: string, @Req() req: any) {
+    await this.membershipService.cancelRequest(
+      req.user.idUser,
+      parseInt(clubId),
+    );
+    return { status: null };
   }
 }

--- a/app/backend/src/membership/membership.module.ts
+++ b/app/backend/src/membership/membership.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Membership } from './membership.entity';
 import { MembershipService } from './membership.service';
 import { MembershipController } from './membership.controller';
+import { Role } from '../role/role.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Membership])],
+  imports: [TypeOrmModule.forFeature([Membership, Role])],
   providers: [MembershipService],
   controllers: [MembershipController],
 })

--- a/app/backend/src/membership/membership.service.ts
+++ b/app/backend/src/membership/membership.service.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Membership } from './membership.entity';
+import { Role } from '../role/role.entity';
 
 @Injectable()
 export class MembershipService {
   constructor(
     @InjectRepository(Membership)
     private readonly membershipRepo: Repository<Membership>,
+    @InjectRepository(Role)
+    private readonly roleRepo: Repository<Role>,
   ) {}
 
   async findMyMembership(userId: number): Promise<Membership | null> {
@@ -26,5 +29,102 @@ export class MembershipService {
         'club.events',
       ],
     });
+  }
+
+  async getStatusForClub(
+    userId: number,
+    clubId: number,
+  ): Promise<{ status: 'active' | 'pending' | 'pending_other' | null; clubName?: string; clubSlug?: string }> {
+    const forThisClub = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: userId },
+        club: { idClub: clubId },
+        season: '2025-2026',
+      },
+    });
+
+    if (forThisClub) {
+      return { status: forThisClub.status as 'active' | 'pending' };
+    }
+
+    const pendingElsewhere = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: userId },
+        status: 'pending',
+        season: '2025-2026',
+      },
+      relations: ['club'],
+    });
+
+    if (pendingElsewhere) {
+      return {
+        status: 'pending_other',
+        clubName: pendingElsewhere.club.name,
+        clubSlug: pendingElsewhere.club.slug
+      };
+    }
+
+    return { status: null };
+  }
+
+  async requestMembership(
+    userId: number,
+    clubId: number,
+  ): Promise<{ status: string }> {
+    // Check no existing membership for this club
+    const existingForClub = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: userId },
+        club: { idClub: clubId },
+        season: '2025-2026',
+      },
+    });
+
+    if (existingForClub) {
+      throw new ConflictException('Une demande existe déjà pour ce club cette saison');
+    }
+
+    // Check no pending request on any other club
+    const pendingElsewhere = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: userId },
+        status: 'pending',
+        season: '2025-2026',
+      },
+    });
+
+    if (pendingElsewhere) {
+      throw new ConflictException('Vous avez déjà une demande en attente sur un autre club');
+    }
+
+    const defaultRole = await this.roleRepo.findOneBy({ codeRole: 'member' });
+
+    await this.membershipRepo.save({
+      user:           { idUser: userId },
+      club:           { idClub: clubId },
+      role:           defaultRole!,
+      season:         '2025-2026',
+      membershipDate: new Date(),
+      status:         'pending',
+    });
+
+    return { status: 'pending' };
+  }
+
+  async cancelRequest(userId: number, clubId: number): Promise<void> {
+    const membership = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: userId },
+        club: { idClub: clubId },
+        status: 'pending',
+        season: '2025-2026',
+      },
+    });
+
+    if (!membership) {
+      throw new NotFoundException('Aucune demande en attente pour ce club');
+    }
+
+    await this.membershipRepo.remove(membership);
   }
 }

--- a/app/frontend/app/clubs/[slug]/_components/JoinClubButton.tsx
+++ b/app/frontend/app/clubs/[slug]/_components/JoinClubButton.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '../../../context/AuthContext';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+
+type Props = { clubId: number };
+type StatusData = {
+  status: 'active' | 'pending' | 'pending_other' | null;
+  clubName?: string;
+  clubSlug?: string;
+};
+
+export default function JoinClubButton({ clubId }: Props) {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const [statusData, setStatusData] = useState<StatusData>({ status: null });
+  const [loadingStatus, setLoadingStatus] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) { setLoadingStatus(false); return; }
+
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/membership/status/${clubId}`, {
+      credentials: 'include',
+    })
+      .then(res => res.json())
+      .then(data => setStatusData(data))
+      .catch(() => setStatusData({ status: null }))
+      .finally(() => setLoadingStatus(false));
+  }, [user, authLoading, clubId]);
+
+  const handleRequest = async () => {
+    if (!user) { router.push('/login'); return; }
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/membership/request/${clubId}`,
+        { method: 'POST', credentials: 'include' },
+      );
+      if (res.ok) setStatusData({ status: 'pending' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/membership/request/${clubId}`,
+        { method: 'DELETE', credentials: 'include' },
+      );
+      if (res.ok) setStatusData({ status: null });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || loadingStatus) {
+    return <div className="w-48 h-14 bg-gray-100 rounded-xl animate-pulse mx-auto" />;
+  }
+
+  if (statusData.status === 'active') {
+    return (
+      <div className="inline-flex items-center gap-2 py-4 px-8 bg-green-50 text-green-700 font-semibold rounded-xl border border-green-200">
+        ✅ Vous êtes membre de ce club
+      </div>
+    );
+  }
+
+  if (statusData.status === 'pending') {
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <div className="inline-flex items-center gap-2 py-4 px-8 bg-yellow-50 text-yellow-700 font-semibold rounded-xl border border-yellow-200">
+          ⏳ Demande en attente de validation
+        </div>
+        <button
+          onClick={handleCancel}
+          disabled={submitting}
+          className="text-sm text-gray-400 hover:text-red-500 underline transition-colors disabled:opacity-50"
+        >
+          {submitting ? 'Annulation...' : 'Annuler ma demande'}
+        </button>
+      </div>
+    );
+  }
+
+  if (statusData.status === 'pending_other') {
+    return (
+      <div className="flex flex-col items-center gap-2 py-4 px-8 bg-gray-50 text-gray-500 rounded-xl border border-gray-200">
+        <p className="font-semibold text-sm">Demande en cours pour rejoindre</p>
+        <Link
+            href={`/clubs/${statusData.clubSlug}`}
+            className="font-bold text-[#0d3b66] hover:underline"
+        >
+            {statusData.clubName}
+        </Link>
+        <p className="text-xs text-gray-400">En attente de validation par le responsable du club.</p>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleRequest}
+      disabled={submitting}
+      className="inline-flex items-center gap-2 py-4 px-8 bg-linear-to-r from-[#0d3b66] to-[#006994] text-white rounded-xl hover:shadow-lg transition-all group disabled:opacity-50"
+    >
+      <span>{submitting ? 'Envoi...' : 'Demander à rejoindre'}</span>
+      <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+    </button>
+  );
+}

--- a/app/frontend/app/clubs/[slug]/page.tsx
+++ b/app/frontend/app/clubs/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { MapPin, Users, Calendar, ArrowLeft, ArrowRight, Mail, Shield } from 'lucide-react';
 import { getClub } from '../../lib/api';
+import JoinClubButton from './_components/JoinClubButton';
 
 export default async function ClubPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
@@ -104,11 +105,7 @@ export default async function ClubPage({ params }: { params: Promise<{ slug: str
           <p className="text-gray-500 mb-6 max-w-2xl mx-auto">
             Envoyez une demande d'adhésion au club. Le président examinera votre demande et vous contactera.
           </p>
-          <button className="inline-flex items-center gap-2 py-4 px-8 bg-linear-to-r from-[#0d3b66] to-[#006994] text-white rounded-xl hover:shadow-lg transition-all group">
-            <span>Demander à rejoindre</span>
-            <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
-          </button>
-          <p className="text-sm text-gray-400 mt-4">Connexion requise pour rejoindre un club</p>
+          <JoinClubButton clubId={club.idClub} />
         </div>
 
       </div>


### PR DESCRIPTION
What
Full membership request flow — a user can request to join a club, cancel their request, and is blocked from requesting multiple clubs simultaneously.

Changes

Backend
- `POST /membership/request/:clubId` - creates a membership with status `pending`
  - Blocks if a request already exists for this club this season
  - Blocks if a pending request exists on any other club
- `DELETE /membership/request/:clubId` - cancels a pending request
- `GET /membership/status/:clubId` - returns the membership status for a given club
  - Returns `active`, `pending`, `pending_other` (with `clubName` and `clubSlug`), or `null`

Frontend
- `JoinClubButton` component - colocated in `clubs/[slug]/_components/`
  - 4 states: can request / pending (with cancel) / pending_other (with link to the club) / active member
  - Non-authenticated users are redirected to `/login` on click

Related to #73 