### PR TITLE
feat(membership): admin validation of membership requests

### DIFF
--- a/app/backend/src/membership/membership.controller.ts
+++ b/app/backend/src/membership/membership.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, Post, Delete, Param, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Param, Req, UseGuards, ForbiddenException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { MembershipService } from './membership.service';
+
+const ADMIN_ROLES = ['admin', 'super_admin'];
 
 @Controller('membership')
 export class MembershipController {
@@ -51,5 +53,36 @@ export class MembershipController {
       parseInt(clubId),
     );
     return { status: null };
+  }
+
+  @Get('pending')
+  @UseGuards(AuthGuard('jwt'))
+  async getPendingRequests(@Req() req: any) {
+    const adminMembership = await this.membershipService.findMyMembership(req.user.idUser);
+    if (!adminMembership || !ADMIN_ROLES.includes(adminMembership.role.codeRole)) {
+      throw new ForbiddenException('Accès réservé aux administrateurs');
+    }
+    return this.membershipService.getPendingRequests(adminMembership.club.idClub);
+  }
+
+  @Patch('request/:membershipId/accept')
+  @UseGuards(AuthGuard('jwt'))
+  async acceptRequest(@Param('membershipId') membershipId: string, @Req() req: any) {
+    const adminMembership = await this.membershipService.findMyMembership(req.user.idUser);
+    if (!adminMembership || !ADMIN_ROLES.includes(adminMembership.role.codeRole)) {
+      throw new ForbiddenException('Accès réservé aux administrateurs');
+    }
+    return this.membershipService.acceptRequest(parseInt(membershipId), adminMembership.club.idClub);
+  }
+
+  @Delete('request/:membershipId/reject')
+  @UseGuards(AuthGuard('jwt'))
+  async rejectRequest(@Param('membershipId') membershipId: string, @Req() req: any) {
+    const adminMembership = await this.membershipService.findMyMembership(req.user.idUser);
+    if (!adminMembership || !ADMIN_ROLES.includes(adminMembership.role.codeRole)) {
+      throw new ForbiddenException('Accès réservé aux administrateurs');
+    }
+    await this.membershipService.rejectRequest(parseInt(membershipId), adminMembership.club.idClub);
+    return { success: true };
   }
 }

--- a/app/backend/src/membership/membership.service.ts
+++ b/app/backend/src/membership/membership.service.ts
@@ -34,7 +34,9 @@ export class MembershipService {
   async getStatusForClub(
     userId: number,
     clubId: number,
-  ): Promise<{ status: 'active' | 'pending' | 'pending_other' | null; clubName?: string; clubSlug?: string }> {
+  ): Promise<{ status: 'active' | 'pending' | 'pending_other' | 'active_other' | null; clubName?: string; clubSlug?: string }> {
+    
+    // Check this specific club first
     const forThisClub = await this.membershipRepo.findOne({
       where: {
         user: { idUser: userId },
@@ -47,6 +49,25 @@ export class MembershipService {
       return { status: forThisClub.status as 'active' | 'pending' };
     }
 
+    // Check active membership on any other club
+    const activeElsewhere = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: userId },
+        status: 'active',
+        season: '2025-2026',
+      },
+      relations: ['club'],
+    });
+
+    if (activeElsewhere) {
+      return {
+        status: 'active_other',
+        clubName: activeElsewhere.club.name,
+        clubSlug: activeElsewhere.club.slug,
+      };
+    }
+
+    // Check pending request on any other club
     const pendingElsewhere = await this.membershipRepo.findOne({
       where: {
         user: { idUser: userId },
@@ -60,69 +81,118 @@ export class MembershipService {
       return {
         status: 'pending_other',
         clubName: pendingElsewhere.club.name,
-        clubSlug: pendingElsewhere.club.slug
+        clubSlug: pendingElsewhere.club.slug,
       };
     }
 
     return { status: null };
   }
-
   async requestMembership(
-    userId: number,
-    clubId: number,
-  ): Promise<{ status: string }> {
-    // Check no existing membership for this club
-    const existingForClub = await this.membershipRepo.findOne({
-      where: {
-        user: { idUser: userId },
-        club: { idClub: clubId },
-        season: '2025-2026',
-      },
-    });
+  userId: number,
+  clubId: number,
+): Promise<{ status: string }> {
+  // Check no existing membership for this club
+  const existingForClub = await this.membershipRepo.findOne({
+    where: {
+      user: { idUser: userId },
+      club: { idClub: clubId },
+      season: '2025-2026',
+    },
+  });
 
-    if (existingForClub) {
-      throw new ConflictException('Une demande existe déjà pour ce club cette saison');
-    }
-
-    // Check no pending request on any other club
-    const pendingElsewhere = await this.membershipRepo.findOne({
-      where: {
-        user: { idUser: userId },
-        status: 'pending',
-        season: '2025-2026',
-      },
-    });
-
-    if (pendingElsewhere) {
-      throw new ConflictException('Vous avez déjà une demande en attente sur un autre club');
-    }
-
-    const defaultRole = await this.roleRepo.findOneBy({ codeRole: 'member' });
-
-    await this.membershipRepo.save({
-      user:           { idUser: userId },
-      club:           { idClub: clubId },
-      role:           defaultRole!,
-      season:         '2025-2026',
-      membershipDate: new Date(),
-      status:         'pending',
-    });
-
-    return { status: 'pending' };
+  if (existingForClub) {
+    throw new ConflictException('Une demande existe déjà pour ce club cette saison');
   }
 
-  async cancelRequest(userId: number, clubId: number): Promise<void> {
-    const membership = await this.membershipRepo.findOne({
+  // Check no pending or active membership on any other club
+  const existingElsewhere = await this.membershipRepo.findOne({
+    where: {
+      user: { idUser: userId },
+      season: '2025-2026',
+    },
+  });
+
+  if (existingElsewhere) {
+    throw new ConflictException('Vous avez déjà un membership actif ou en attente sur un autre club');
+  }
+
+  const defaultRole = await this.roleRepo.findOneBy({ codeRole: 'member' });
+
+  await this.membershipRepo.save({
+    user:           { idUser: userId },
+    club:           { idClub: clubId },
+    role:           defaultRole!,
+    season:         '2025-2026',
+    membershipDate: new Date(),
+    status:         'pending',
+  });
+
+  return { status: 'pending' };
+}
+
+    async cancelRequest(userId: number, clubId: number): Promise<void> {
+      const membership = await this.membershipRepo.findOne({
+        where: {
+          user: { idUser: userId },
+          club: { idClub: clubId },
+          status: 'pending',
+          season: '2025-2026',
+        },
+      });
+
+      if (!membership) {
+        throw new NotFoundException('Aucune demande en attente pour ce club');
+      }
+
+      await this.membershipRepo.remove(membership);
+    }
+
+  async getPendingRequests(clubId: number): Promise<Membership[]> {
+    const memberships = await this.membershipRepo.find({
       where: {
-        user: { idUser: userId },
         club: { idClub: clubId },
         status: 'pending',
-        season: '2025-2026',
+      },
+      relations: ['user'],
+    });
+
+    return memberships.map((m) => {
+      const { passwordHash: _, ...safeUser } = m.user as any;
+      return { ...m, user: safeUser };
+    }) as Membership[];
+  }
+
+  async acceptRequest(membershipId: number, clubId: number): Promise<{ success: boolean }> {
+    const membership = await this.membershipRepo.findOne({
+      where: {
+        idMembership: membershipId,
+        club: { idClub: clubId },
+        status: 'pending',
       },
     });
 
     if (!membership) {
-      throw new NotFoundException('Aucune demande en attente pour ce club');
+      throw new NotFoundException('Demande introuvable');
+    }
+
+    membership.status = 'active';
+    membership.decisionDate = new Date();
+    await this.membershipRepo.save(membership);
+
+    return { success: true };
+  }
+
+  async rejectRequest(membershipId: number, clubId: number): Promise<void> {
+    const membership = await this.membershipRepo.findOne({
+      where: {
+        idMembership: membershipId,
+        club: { idClub: clubId },
+        status: 'pending',
+      },
+    });
+
+    if (!membership) {
+      throw new NotFoundException('Demande introuvable');
     }
 
     await this.membershipRepo.remove(membership);

--- a/app/frontend/app/clubs/[slug]/_components/JoinClubButton.tsx
+++ b/app/frontend/app/clubs/[slug]/_components/JoinClubButton.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 
 type Props = { clubId: number };
 type StatusData = {
-  status: 'active' | 'pending' | 'pending_other' | null;
+  status: 'active' | 'pending' | 'pending_other' | 'active_other' | null;
   clubName?: string;
   clubSlug?: string;
 };
@@ -71,6 +71,20 @@ export default function JoinClubButton({ clubId }: Props) {
       </div>
     );
   }
+
+    if (statusData.status === 'active_other') {
+    return (
+        <div className="flex flex-col items-center gap-2 py-4 px-8 bg-gray-50 text-gray-500 rounded-xl border border-gray-200">
+        <p className="font-semibold text-sm">Vous êtes déjà membre de</p>
+        <Link
+            href={`/clubs/${statusData.clubSlug}`}
+            className="font-bold text-[#0d3b66] hover:underline"
+        >
+            {statusData.clubName}
+        </Link>
+        </div>
+    );
+    }
 
   if (statusData.status === 'pending') {
     return (

--- a/app/frontend/app/dashboard/members/page.tsx
+++ b/app/frontend/app/dashboard/members/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '../../context/AuthContext';
 import { useMembership } from '../../hooks/useMembership';
-import { Users } from 'lucide-react';
+import { Users, Check, X } from 'lucide-react';
 import Link from 'next/link';
 
 const LEVEL_COLORS: Record<string, string> = {
@@ -24,16 +24,66 @@ const ROLE_LABELS: Record<string, string> = {
   member:      'Adhérent',
 };
 
+const ADMIN_ROLES = ['admin', 'super_admin'];
+
+type PendingRequest = {
+  idMembership: number;
+  status: string;
+  user: {
+    idUser: number;
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+};
+
 export default function MembersPage() {
   const { user, loading: authLoading } = useAuth();
   const { membership, loading: membershipLoading } = useMembership();
   const router = useRouter();
+  const [pendingRequests, setPendingRequests] = useState<PendingRequest[]>([]);
+  const [loadingPending, setLoadingPending] = useState(false);
 
   useEffect(() => {
     if (!authLoading && !user) {
       router.push('/login');
     }
   }, [user, authLoading, router]);
+
+  // Fetch pending requests if admin
+  useEffect(() => {
+    if (!membership) return;
+    if (!ADMIN_ROLES.includes(membership.role.codeRole)) return;
+
+    setLoadingPending(true);
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/membership/pending`, {
+      credentials: 'include',
+    })
+      .then(res => res.json())
+      .then(data => setPendingRequests(data))
+      .catch(() => setPendingRequests([]))
+      .finally(() => setLoadingPending(false));
+  }, [membership]);
+
+  const handleAccept = async (membershipId: number) => {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/membership/request/${membershipId}/accept`,
+      { method: 'PATCH', credentials: 'include' },
+    );
+    if (res.ok) {
+      setPendingRequests(prev => prev.filter(r => r.idMembership !== membershipId));
+    }
+  };
+
+  const handleReject = async (membershipId: number) => {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/membership/request/${membershipId}/reject`,
+      { method: 'DELETE', credentials: 'include' },
+    );
+    if (res.ok) {
+      setPendingRequests(prev => prev.filter(r => r.idMembership !== membershipId));
+    }
+  };
 
   if (authLoading || membershipLoading) {
     return (
@@ -72,6 +122,7 @@ export default function MembersPage() {
     );
   }
 
+  const isAdmin = ADMIN_ROLES.includes(membership.role.codeRole);
   const activeMembers = membership.club.memberships.filter(m => m.status === 'active');
 
   return (
@@ -84,6 +135,52 @@ export default function MembersPage() {
         </p>
       </div>
 
+      {/* Pending requests — admin only */}
+      {isAdmin && !loadingPending && pendingRequests.length > 0 && (
+        <div className="bg-white rounded-2xl shadow-xl overflow-hidden mb-6">
+          <div className="px-6 py-4 border-b border-gray-100 flex items-center gap-2">
+            <h2 className="font-bold text-[#0d3b66]">Demandes en attente</h2>
+            <span className="bg-yellow-100 text-yellow-700 text-xs font-medium px-2.5 py-0.5 rounded-full">
+              {pendingRequests.length}
+            </span>
+          </div>
+          <div className="divide-y divide-gray-50">
+            {pendingRequests.map(request => (
+              <div key={request.idMembership} className="px-6 py-4 flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-xl bg-yellow-100 flex items-center justify-center text-yellow-700 text-sm font-semibold shrink-0">
+                    {request.user.firstName?.[0]}{request.user.lastName?.[0]}
+                  </div>
+                  <div>
+                    <p className="font-medium text-[#0d3b66]">
+                      {request.user.firstName} {request.user.lastName}
+                    </p>
+                    <p className="text-xs text-gray-400">{request.user.email}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    onClick={() => handleAccept(request.idMembership)}
+                    className="flex items-center gap-1.5 px-3 py-1.5 bg-green-50 text-green-700 text-sm font-medium rounded-lg hover:bg-green-100 transition-colors"
+                  >
+                    <Check className="w-4 h-4" />
+                    Accepter
+                  </button>
+                  <button
+                    onClick={() => handleReject(request.idMembership)}
+                    className="flex items-center gap-1.5 px-3 py-1.5 bg-red-50 text-red-600 text-sm font-medium rounded-lg hover:bg-red-100 transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                    Refuser
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Active members table */}
       <div className="bg-white rounded-2xl shadow-xl overflow-hidden">
         <table className="w-full text-sm">
           <thead className="bg-gray-50 border-b border-gray-100">


### PR DESCRIPTION
What
Admins can now see and validate pending membership requests directly from the members page. A user with an active membership is blocked from joining another club.

Changes

Backend
- `GET /membership/pending` — returns pending requests for the admin's club (admin/super_admin only)
- `PATCH /membership/request/:membershipId/accept` — validates a pending request → status becomes `active`
- `DELETE /membership/request/:membershipId/reject` — rejects and removes a pending request
- `GET /membership/status/:clubId` — now returns `active_other` (with `clubName` and `clubSlug`) when user is already an active member of another club

Frontend
- `/dashboard/members` — "Demandes en attente" section visible for admin and super_admin only, with Accept / Reject buttons and optimistic UI update
- `JoinClubButton` — new `active_other` state displays the name of the current club with a link, blocking the user from requesting another club

Related to #193 