### PR TITLE
fix(ui): prevent mobile auto-zoom on input focus

### DIFF
--- a/app/frontend/app/globals.css
+++ b/app/frontend/app/globals.css
@@ -41,4 +41,6 @@ body {
   max-width: 100%;
 }
 
-
+input, textarea, select {
+  font-size: 16px !important;
+}


### PR DESCRIPTION
Add global CSS rule to prevent mobile auto-zoom on input focus, which was causing layout width distortion on mobile.

Related to #195 