### PR TITLE
fix(dashboard): hide level and role columns on mobile in members table

### DIFF
--- a/app/frontend/app/dashboard/members/page.tsx
+++ b/app/frontend/app/dashboard/members/page.tsx
@@ -187,7 +187,7 @@ export default function MembersPage() {
             <tr>
               <th className="text-left px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide">Membre</th>
               <th className="text-left px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide hidden md:table-cell">Niveau</th>
-              <th className="text-left px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide">Rôle</th>
+              <th className="text-left px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide hidden md:table-cell">Rôle</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
@@ -211,8 +211,8 @@ export default function MembersPage() {
                     {member.user.technicalLevel ?? '—'}
                   </span>
                 </td>
-                <td className="px-6 py-4">
-                  <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full">
+                <td className="px-6 py-4 hidden md:table-cell">
+                  <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full whitespace-nowrap">
                     {ROLE_LABELS[member.role.codeRole] ?? member.role.labelRole}
                   </span>
                 </td>


### PR DESCRIPTION
Delete tags on mobile version
<img width="305" height="588" alt="Capture d’écran 2026-04-23 à 10 50 48" src="https://github.com/user-attachments/assets/91ccd0ba-e17e-4a08-b5bc-51fe108df45c" />

Related to (#197)