### PR TITLE
test(e2e): add Playwright auth tests and CI workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,35 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+
+    - name: Install frontend dependencies
+      working-directory: frontend
+      run: npm ci
+
+    - name: Install Playwright Browsers
+      working-directory: frontend
+      run: npx playwright install --with-deps
+
+    - name: Run Playwright tests
+      working-directory: frontend
+      run: npx playwright test
+
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: frontend/playwright-report/
+        retention-days: 30

--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand --forceExit",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d src/database/data-source.ts",
     "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/database/data-source.ts",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/database/data-source.ts",

--- a/app/backend/src/membership/membership.service.spec.ts
+++ b/app/backend/src/membership/membership.service.spec.ts
@@ -1,0 +1,191 @@
+// backend/src/membership/membership.service.spec.ts
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MembershipService } from './membership.service';
+import { Membership } from './membership.entity';
+import { Role } from '../role/role.entity';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const mockMembershipRepo = {
+  findOne: jest.fn(),
+  find:    jest.fn(),
+  save:    jest.fn(),
+  remove:  jest.fn(),
+};
+
+const mockRoleRepo = {
+  findOneBy: jest.fn(),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const makeMembership = (overrides: Partial<Membership> = {}): Membership => ({
+  idMembership:  1,
+  status:        'active',
+  season:        '2025-2026',
+  membershipDate: new Date(),
+  decisionDate: null as unknown as Date,
+  user: { idUser: 1, email: 'test@test.com' } as any,
+  club: { idClub: 1, name: 'Aquaclub21', slug: 'aquaclub21' } as any,
+  role: { codeRole: 'member', labelRole: 'Member' } as any,
+  ...overrides,
+});
+
+// ── Suite ──────────────────────────────────────────────────────────────────
+describe('MembershipService', () => {
+  let service: MembershipService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MembershipService,
+        { provide: getRepositoryToken(Membership), useValue: mockMembershipRepo },
+        { provide: getRepositoryToken(Role),       useValue: mockRoleRepo },
+      ],
+    }).compile();
+
+    service = module.get<MembershipService>(MembershipService);
+    jest.clearAllMocks();
+  });
+
+  // ── getStatusForClub ───────────────────────────────────────────────────
+  describe('getStatusForClub', () => {
+
+    it('should return null when no membership is found', async () => {
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getStatusForClub(1, 1);
+      expect(result).toEqual({ status: null });
+    });
+
+    it('should return active when user has an active membership for this club', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(makeMembership({ status: 'active' }));
+
+      const result = await service.getStatusForClub(1, 1);
+      expect(result).toEqual({ status: 'active' });
+    });
+
+    it('should return pending when user has a pending request for this club', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(makeMembership({ status: 'pending' }));
+
+      const result = await service.getStatusForClub(1, 1);
+      expect(result).toEqual({ status: 'pending' });
+    });
+
+    it('should return active_other when user is an active member of a different club', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(null); // no membership for this club
+      mockMembershipRepo.findOne.mockResolvedValueOnce(      // active elsewhere
+        makeMembership({ status: 'active', club: { idClub: 2, name: 'Neptune', slug: 'neptune' } as any })
+      );
+
+      const result = await service.getStatusForClub(1, 1);
+      expect(result.status).toBe('active_other');
+    });
+
+    it('should return pending_other with clubName and clubSlug when user has a pending request for a different club', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(null); // no membership for this club
+      mockMembershipRepo.findOne.mockResolvedValueOnce(null); // no active elsewhere
+      mockMembershipRepo.findOne.mockResolvedValueOnce(       // pending elsewhere
+        makeMembership({
+          status: 'pending',
+          club: { idClub: 3, name: 'Neptune Marseille', slug: 'neptune-marseille' } as any,
+        })
+      );
+
+      const result = await service.getStatusForClub(1, 1);
+      expect(result).toEqual({
+        status:   'pending_other',
+        clubName: 'Neptune Marseille',
+        clubSlug: 'neptune-marseille',
+      });
+    });
+  });
+
+  // ── requestMembership ──────────────────────────────────────────────────
+  describe('requestMembership', () => {
+
+    it('should create a pending membership successfully', async () => {
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+      mockRoleRepo.findOneBy.mockResolvedValue({ codeRole: 'member' });
+      mockMembershipRepo.save.mockResolvedValue(makeMembership({ status: 'pending' }));
+
+      const result = await service.requestMembership(1, 1);
+      expect(result).toEqual({ status: 'pending' });
+      expect(mockMembershipRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw ConflictException when a request already exists for this club', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(makeMembership({ status: 'pending' }));
+
+      await expect(service.requestMembership(1, 1)).rejects.toThrow(ConflictException);
+    });
+
+    it('should throw ConflictException when user already has a membership elsewhere', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(null);
+      mockMembershipRepo.findOne.mockResolvedValueOnce(makeMembership({ status: 'active' }));
+
+      await expect(service.requestMembership(1, 2)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ── cancelRequest ──────────────────────────────────────────────────────
+  describe('cancelRequest', () => {
+
+    it('should remove the pending membership successfully', async () => {
+      const membership = makeMembership({ status: 'pending' });
+      mockMembershipRepo.findOne.mockResolvedValue(membership);
+      mockMembershipRepo.remove.mockResolvedValue(undefined);
+
+      await service.cancelRequest(1, 1);
+      expect(mockMembershipRepo.remove).toHaveBeenCalledWith(membership);
+    });
+
+    it('should throw NotFoundException when no pending request is found', async () => {
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.cancelRequest(1, 1)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── acceptRequest ──────────────────────────────────────────────────────
+  describe('acceptRequest', () => {
+
+    it('should set membership status to active and set decisionDate', async () => {
+      const membership = makeMembership({ status: 'pending' });
+      mockMembershipRepo.findOne.mockResolvedValue(membership);
+      mockMembershipRepo.save.mockResolvedValue({ ...membership, status: 'active' });
+
+      const result = await service.acceptRequest(1, 1);
+      expect(result).toEqual({ success: true });
+      expect(mockMembershipRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'active', decisionDate: expect.any(Date) })
+      );
+    });
+
+    it('should throw NotFoundException when membership is not found', async () => {
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.acceptRequest(99, 1)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── rejectRequest ──────────────────────────────────────────────────────
+  describe('rejectRequest', () => {
+
+    it('should remove the pending membership successfully', async () => {
+      const membership = makeMembership({ status: 'pending' });
+      mockMembershipRepo.findOne.mockResolvedValue(membership);
+      mockMembershipRepo.remove.mockResolvedValue(undefined);
+
+      await service.rejectRequest(1, 1);
+      expect(mockMembershipRepo.remove).toHaveBeenCalledWith(membership);
+    });
+
+    it('should throw NotFoundException when membership is not found', async () => {
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.rejectRequest(99, 1)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/app/backend/test/auth.e2e-spec.ts
+++ b/app/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { DataSource } from 'typeorm';
+import cookieParser = require('cookie-parser');
+
+describe('Auth (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+    beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+
+    dataSource = moduleFixture.get(DataSource);
+
+    // Clean once before all tests
+    await dataSource.query(`DELETE FROM app_user WHERE email LIKE '%@e2e-test.com'`);
+    });
+
+    beforeEach(async () => {
+    // Only clean between tests, don't reinit the app
+    await dataSource.query(`DELETE FROM app_user WHERE email LIKE '%@e2e-test.com'`);
+    });
+
+    afterAll(async () => {
+    await dataSource.query(`DELETE FROM app_user WHERE email LIKE '%@e2e-test.com'`);
+    await dataSource.destroy();
+    await app.close();
+    });
+
+  // ── POST /auth/register ──────────────────────────────────────────────────
+  describe('POST /auth/register', () => {
+
+    it('should register a new user and return 201', async () => {
+    const res = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+        email:     'register@e2e-test.com',
+        password:  'Test1234!',
+        firstName: 'Test',
+        lastName:  'User',
+        });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('message');
+    });
+
+    it('should return 409 when email already exists', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({ email: 'duplicate@e2e-test.com', password: 'Test1234!', firstName: 'Test', lastName: 'User' });
+
+      const res = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({ email: 'duplicate@e2e-test.com', password: 'Test1234!', firstName: 'Test', lastName: 'User' });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('should return 400 when required fields are missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({ email: 'incomplete@e2e-test.com' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── POST /auth/login ─────────────────────────────────────────────────────
+  describe('POST /auth/login', () => {
+
+    beforeEach(async () => {
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({ email: 'login@e2e-test.com', password: 'Test1234!', firstName: 'Test', lastName: 'User' });
+    });
+
+    it('should login successfully and set JWT cookie', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: 'login@e2e-test.com', password: 'Test1234!' });
+
+      expect(res.status).toBe(201);
+      expect(res.headers['set-cookie']).toBeDefined();
+      expect(res.headers['set-cookie'][0]).toContain('access_token');
+    });
+
+    it('should return 401 with wrong password', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: 'login@e2e-test.com', password: 'WrongPassword!' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 401 with unknown email', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: 'unknown@e2e-test.com', password: 'Test1234!' });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── GET /auth/me ─────────────────────────────────────────────────────────
+  describe('GET /auth/me', () => {
+
+    it('should return user info with valid JWT cookie', async () => {
+    await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({ email: 'me@e2e-test.com', password: 'Test1234!', firstName: 'Test', lastName: 'User' });
+
+    const loginRes = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: 'me@e2e-test.com', password: 'Test1234!' });
+
+    const cookie = loginRes.headers['set-cookie'] as unknown as string[];
+
+    const res = await request(app.getHttpServer())
+        .get('/auth/me')
+        .set('Cookie', cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('me@e2e-test.com');
+    expect(res.body).not.toHaveProperty('passwordHash');
+    });
+  });
+});

--- a/app/backend/test/jest-e2e.json
+++ b/app/backend/test/jest-e2e.json
@@ -4,6 +4,9 @@
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
+    "^.+\\.(t|j)s$": ["ts-jest", {
+      "tsconfig": "<rootDir>/../tsconfig.json"
+    }]
+  },
+  "setupFiles": ["dotenv/config"]
 }

--- a/app/backend/test/membership.e2e-spec.ts
+++ b/app/backend/test/membership.e2e-spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { DataSource } from 'typeorm';
+import cookieParser = require('cookie-parser');
+
+describe('Membership (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let memberCookie: string;
+  let adminCookie: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+
+    dataSource = moduleFixture.get(DataSource);
+  });
+
+  beforeEach(async () => {
+    // Clean test data
+    await dataSource.query(`
+      DELETE FROM membership WHERE id_user IN (
+        SELECT id_user FROM app_user WHERE email LIKE '%@membership-test.com'
+      )
+    `);
+    await dataSource.query(`DELETE FROM app_user WHERE email LIKE '%@membership-test.com'`);
+
+    // Create member user
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'member@membership-test.com', password: 'Test1234!', firstName: 'Test', lastName: 'Member' });
+
+    const memberLogin = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'member@membership-test.com', password: 'Test1234!' });
+    memberCookie = memberLogin.headers['set-cookie'];
+
+    // Login as existing admin (admin@test.com from seed)
+    const adminLogin = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'admin@test.com', password: '123' });
+    adminCookie = adminLogin.headers['set-cookie'];
+  });
+
+  afterAll(async () => {
+    await dataSource.query(`
+      DELETE FROM membership WHERE id_user IN (
+        SELECT id_user FROM app_user WHERE email LIKE '%@membership-test.com'
+      )
+    `);
+    await dataSource.query(`DELETE FROM app_user WHERE email LIKE '%@membership-test.com'`);
+    await dataSource.destroy();
+    await app.close();
+  });
+
+  // ── POST /membership/request/:clubId ─────────────────────────────────────
+  describe('POST /membership/request/:clubId', () => {
+
+    it('should create a pending membership successfully', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(201);
+      expect(res.body.status).toBe('pending');
+    });
+
+    it('should return 401 when not authenticated', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/membership/request/1');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 409 when request already exists for this club', async () => {
+      await request(app.getHttpServer())
+        .post('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      const res = await request(app.getHttpServer())
+        .post('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(409);
+    });
+
+    it('should return 409 when user already has a membership elsewhere', async () => {
+      await request(app.getHttpServer())
+        .post('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      const res = await request(app.getHttpServer())
+        .post('/membership/request/2')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(409);
+    });
+  });
+
+  // ── DELETE /membership/request/:clubId ───────────────────────────────────
+  describe('DELETE /membership/request/:clubId', () => {
+
+    it('should cancel a pending request successfully', async () => {
+      await request(app.getHttpServer())
+        .post('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      const res = await request(app.getHttpServer())
+        .delete('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBeNull();
+    });
+
+    it('should return 404 when no pending request exists', async () => {
+      const res = await request(app.getHttpServer())
+        .delete('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ── GET /membership/status/:clubId ───────────────────────────────────────
+  describe('GET /membership/status/:clubId', () => {
+
+    it('should return null when no membership exists', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/membership/status/1')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBeNull();
+    });
+
+    it('should return pending after requesting to join', async () => {
+      await request(app.getHttpServer())
+        .post('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      const res = await request(app.getHttpServer())
+        .get('/membership/status/1')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('pending');
+    });
+
+    it('should return 401 when not authenticated', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/membership/status/1');
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── GET /membership/pending ──────────────────────────────────────────────
+  describe('GET /membership/pending', () => {
+
+    it('should return pending requests for admin', async () => {
+      await request(app.getHttpServer())
+        .post('/membership/request/1')
+        .set('Cookie', memberCookie);
+
+      const res = await request(app.getHttpServer())
+        .get('/membership/pending')
+        .set('Cookie', adminCookie);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it('should return 403 when user is not an admin', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/membership/pending')
+        .set('Cookie', memberCookie);
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should return 401 when not authenticated', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/membership/pending');
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/app/frontend/.gitignore
+++ b/app/frontend/.gitignore
@@ -39,3 +39,11 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "19.2.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1225,6 +1226,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3586,6 +3603,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5294,6 +5325,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -15,6 +15,7 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/app/frontend/playwright.config.ts
+++ b/app/frontend/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+  },
+});

--- a/app/frontend/tests/auth.spec.ts
+++ b/app/frontend/tests/auth.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_EMAIL = `playwright-${TIMESTAMP}@e2e-test.com`;
+const TEST_PASSWORD = 'Test1234!';
+
+test.describe('Authentication', () => {
+
+  test('should redirect to /login when accessing /dashboard without auth', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('should register a new user successfully', async ({ page }) => {
+    await page.goto('/register');
+
+    await page.getByPlaceholder('Kevin').fill('Playwright');
+    await page.getByPlaceholder('Dupont').fill('Test');
+    await page.getByPlaceholder('vous@exemple.fr').fill(TEST_EMAIL);
+    await page.getByPlaceholder('••••••••').fill(TEST_PASSWORD);
+
+    await page.getByRole('button', { name: /créer mon compte/i }).click();
+
+    await expect(page.getByText('Compte créé avec succès')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should login successfully and access dashboard', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByPlaceholder('vous@exemple.fr').fill('adherent@test.com');
+    await page.getByPlaceholder('••••••••').fill('123');
+
+    await page.getByRole('button', { name: /se connecter/i }).click();
+
+    await expect(page).toHaveURL('/dashboard', { timeout: 5000 });
+  });
+
+  test('should show error with wrong password', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByPlaceholder('vous@exemple.fr').fill('adherent@test.com');
+    await page.getByPlaceholder('••••••••').fill('wrongpassword');
+
+    await page.getByRole('button', { name: /se connecter/i }).click();
+
+    await expect(page.getByText(/identifiants incorrects/i)).toBeVisible({ timeout: 3000 });
+  });
+});

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
## What
Full automated test suite covering unit, integration and end-to-end testing.

## Changes

### Jest — Unit tests
- `membership.service.spec.ts` — 14 tests covering all MembershipService methods
  - getStatusForClub — 5 cases: null / active / pending / active_other / pending_other
  - requestMembership — nominal + conflict + duplicate
  - cancelRequest — nominal + not found
  - acceptRequest — nominal + not found
  - rejectRequest — nominal + not found

### Supertest — Integration tests
- `auth.e2e-spec.ts` — POST /auth/register, POST /auth/login, GET /auth/me
- `membership.e2e-spec.ts` — POST /membership/request, DELETE /membership/request, GET /membership/status, GET /membership/pending

### Playwright — E2E tests
- `auth.spec.ts` — redirect to /login without auth, register, login, wrong password error

### CI
- `.github/workflows/playwright.yml` — Playwright workflow on push/PR to main and develop

Related to #200 