### PR TITLE
feat(members): role management, expulsion and club-scoped authorization

### DIFF
--- a/app/backend/src/event/event.service.spec.ts
+++ b/app/backend/src/event/event.service.spec.ts
@@ -1,0 +1,186 @@
+// backend/src/event/event.service.spec.ts
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { EventService } from './event.service';
+import { ClubEvent } from './event.entity';
+import { Membership } from '../membership/membership.entity';
+import { LogService } from '../log/log.service';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const mockEventRepo = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+};
+
+const mockMembershipRepo = {
+  findOne: jest.fn(),
+};
+
+const mockLogService = {
+  logAuth: jest.fn(),
+  logMembership: jest.fn(),
+  logError: jest.fn(),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const makeMembership = (codeRole: string, clubId: number): Membership =>
+  ({
+    idMembership: 1,
+    status: 'active',
+    role: { codeRole, labelRole: codeRole } as any,
+    club: { idClub: clubId } as any,
+    user: { idUser: 1 } as any,
+  }) as Membership;
+
+const validDto = {
+  title: 'Sortie fosse',
+  startDatetime: '2026-07-01T10:00:00.000Z',
+  endDatetime: '2026-07-01T12:00:00.000Z',
+} as any;
+
+// ── Suite ──────────────────────────────────────────────────────────────────
+describe('EventService', () => {
+  let service: EventService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventService,
+        { provide: getRepositoryToken(ClubEvent), useValue: mockEventRepo },
+        {
+          provide: getRepositoryToken(Membership),
+          useValue: mockMembershipRepo,
+        },
+        { provide: LogService, useValue: mockLogService },
+      ],
+    }).compile();
+
+    service = module.get<EventService>(EventService);
+    jest.clearAllMocks();
+  });
+
+  // ── create ───────────────────────────────────────────────────────────────
+  describe('create', () => {
+    it('should create the event when user is a manager of the targeted club', async () => {
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('admin', 1));
+      mockEventRepo.create.mockImplementation((e: object) => e);
+      mockEventRepo.save.mockImplementation((e: object) => Promise.resolve(e));
+
+      await service.create(1, 1, validDto);
+
+      // the role check is properly scoped to the targeted club
+      expect(mockMembershipRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            user: { idUser: 1 },
+            club: { idClub: 1 },
+            status: 'active',
+          }),
+        }),
+      );
+      expect(mockEventRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forbid creating an event in a club where the user is not a manager (cross-club)', async () => {
+      // admin of club 1, but no active manager membership in club 2
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.create(1, 2, validDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockMembershipRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ club: { idClub: 2 } }),
+        }),
+      );
+      expect(mockEventRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should forbid a plain member', async () => {
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('member', 1));
+
+      await expect(service.create(1, 1, validDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockEventRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── update ───────────────────────────────────────────────────────────────
+  describe('update', () => {
+    it('should check the role against the event club, not just any club', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        club: { idClub: 5 },
+      });
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('admin', 5));
+      mockEventRepo.save.mockImplementation((e: object) => Promise.resolve(e));
+
+      await service.update(1, 10, { title: 'Modifié' } as any);
+
+      expect(mockMembershipRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ club: { idClub: 5 } }),
+        }),
+      );
+      expect(mockEventRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forbid a manager of another club from updating the event', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        club: { idClub: 5 },
+      });
+      // no active manager membership in club 5
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update(1, 10, { title: 'Modifié' } as any),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockEventRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the event does not exist', async () => {
+      mockEventRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.update(1, 999, {} as any)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── delete ───────────────────────────────────────────────────────────────
+  describe('delete', () => {
+    it('should remove the event when user is a manager of the event club', async () => {
+      const event = { idEvent: 10, club: { idClub: 5 } };
+      mockEventRepo.findOne.mockResolvedValue(event);
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('admin', 5));
+
+      await service.delete(1, 10);
+
+      expect(mockMembershipRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ club: { idClub: 5 } }),
+        }),
+      );
+      expect(mockEventRepo.remove).toHaveBeenCalledWith(event);
+    });
+
+    it('should forbid a manager of another club from deleting the event', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        club: { idClub: 5 },
+      });
+      mockMembershipRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.delete(1, 10)).rejects.toThrow(ForbiddenException);
+      expect(mockEventRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/backend/src/event/event.service.ts
+++ b/app/backend/src/event/event.service.ts
@@ -23,15 +23,22 @@ export class EventService {
     private readonly logService: LogService,
   ) {}
 
-  private async assertManager(userId: number): Promise<Membership> {
+  private async assertManager(
+    userId: number,
+    clubId: number,
+  ): Promise<Membership> {
     const membership = await this.membershipRepo.findOne({
-      where: { user: { idUser: userId }, status: 'active' },
+      where: {
+        user: { idUser: userId },
+        club: { idClub: clubId },
+        status: 'active',
+      },
       relations: ['role', 'club'],
     });
 
     if (!membership || !MANAGER_ROLES.includes(membership.role.codeRole)) {
       throw new ForbiddenException(
-        'Accès réservé aux moniteurs et administrateurs',
+        'Accès réservé aux moniteurs et administrateurs de ce club',
       );
     }
 
@@ -71,7 +78,7 @@ export class EventService {
     clubId: number,
     dto: CreateEventDto,
   ): Promise<ClubEvent> {
-    const membership = await this.assertManager(userId);
+    await this.assertManager(userId, clubId);
 
     const event = this.eventRepo.create({
       ...dto,
@@ -86,7 +93,7 @@ export class EventService {
     await this.logService.logMembership({
       action: 'event_created',
       actorId: userId,
-      clubId: membership.club.idClub,
+      clubId,
     });
 
     return saved;
@@ -97,14 +104,14 @@ export class EventService {
     eventId: number,
     dto: UpdateEventDto,
   ): Promise<ClubEvent> {
-    await this.assertManager(userId);
-
     const event = await this.eventRepo.findOne({
       where: { idEvent: eventId },
       relations: ['club'],
     });
 
     if (!event) throw new NotFoundException('Événement introuvable');
+
+    await this.assertManager(userId, event.club.idClub);
 
     Object.assign(event, {
       ...dto,
@@ -124,14 +131,14 @@ export class EventService {
   }
 
   async delete(userId: number, eventId: number): Promise<void> {
-    await this.assertManager(userId);
-
     const event = await this.eventRepo.findOne({
       where: { idEvent: eventId },
       relations: ['club'],
     });
 
     if (!event) throw new NotFoundException('Événement introuvable');
+
+    await this.assertManager(userId, event.club.idClub);
 
     await this.eventRepo.remove(event);
 

--- a/app/backend/src/membership/dto/change-role.dto.ts
+++ b/app/backend/src/membership/dto/change-role.dto.ts
@@ -1,0 +1,7 @@
+import { IsIn, IsString } from 'class-validator';
+
+export class ChangeRoleDto {
+  @IsString()
+  @IsIn(['admin', 'committee', 'instructor', 'member'])
+  codeRole: string;
+}

--- a/app/backend/src/membership/members.controller.ts
+++ b/app/backend/src/membership/members.controller.ts
@@ -1,0 +1,40 @@
+import {
+  Controller,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
+import { MembershipService } from './membership.service';
+import { ChangeRoleDto } from './dto/change-role.dto';
+
+type AuthReq = Request & { user: { idUser: number; email: string } };
+
+@Controller('members')
+export class MembersController {
+  constructor(private readonly membershipService: MembershipService) {}
+
+  @Patch(':id/role')
+  @UseGuards(AuthGuard('jwt'))
+  async changeRole(
+    @Param('id') id: string,
+    @Body() dto: ChangeRoleDto,
+    @Req() req: AuthReq,
+  ) {
+    return this.membershipService.changeMemberRole(
+      req.user.idUser,
+      parseInt(id),
+      dto.codeRole,
+    );
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard('jwt'))
+  async expel(@Param('id') id: string, @Req() req: AuthReq) {
+    return this.membershipService.expelMember(req.user.idUser, parseInt(id));
+  }
+}

--- a/app/backend/src/membership/membership.module.ts
+++ b/app/backend/src/membership/membership.module.ts
@@ -3,12 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Membership } from './membership.entity';
 import { MembershipService } from './membership.service';
 import { MembershipController } from './membership.controller';
+import { MembersController } from './members.controller';
 import { Role } from '../role/role.entity';
 import { LogModule } from '../log/log.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Membership, Role]), LogModule],
   providers: [MembershipService],
-  controllers: [MembershipController],
+  controllers: [MembershipController, MembersController],
 })
 export class MembershipModule {}

--- a/app/backend/src/membership/membership.service.spec.ts
+++ b/app/backend/src/membership/membership.service.spec.ts
@@ -6,7 +6,11 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { MembershipService } from './membership.service';
 import { Membership } from './membership.entity';
 import { Role } from '../role/role.entity';
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { LogService } from '../log/log.service';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
@@ -226,6 +230,141 @@ describe('MembershipService', () => {
       mockMembershipRepo.findOne.mockResolvedValue(null);
 
       await expect(service.rejectRequest(99, 1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── changeMemberRole ───────────────────────────────────────────────────
+  describe('changeMemberRole', () => {
+    // admin (idUser 1) of club 1, target member (idMembership 2, idUser 5)
+    const adminMembership = makeMembership({
+      role: { codeRole: 'admin', labelRole: 'Administrateur' } as any,
+    });
+    const targetMembership = makeMembership({
+      idMembership: 2,
+      user: { idUser: 5, email: 'target@test.com' } as any,
+      role: { codeRole: 'member', labelRole: 'Adhérent' } as any,
+    });
+
+    it('should update the role when actor is admin of the club', async () => {
+      mockMembershipRepo.findOne
+        .mockResolvedValueOnce(targetMembership) // load target
+        .mockResolvedValueOnce(adminMembership); // assertClubAdmin
+      mockRoleRepo.findOneBy.mockResolvedValue({ codeRole: 'instructor' });
+      mockMembershipRepo.save.mockResolvedValue(targetMembership);
+
+      const result = await service.changeMemberRole(1, 2, 'instructor');
+      expect(result).toEqual({ success: true });
+      expect(mockMembershipRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw ForbiddenException for a non-assignable role (e.g. super_admin)', async () => {
+      await expect(
+        service.changeMemberRole(1, 2, 'super_admin'),
+      ).rejects.toThrow(ForbiddenException);
+      // rejected before any query
+      expect(mockMembershipRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException when actor is not admin of the club', async () => {
+      mockMembershipRepo.findOne
+        .mockResolvedValueOnce(targetMembership)
+        .mockResolvedValueOnce(null); // no admin membership for this club
+      await expect(service.changeMemberRole(1, 2, 'instructor')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockMembershipRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should forbid changing your own role', async () => {
+      const ownMembership = makeMembership({
+        idMembership: 2,
+        user: { idUser: 1, email: 'me@test.com' } as any,
+        role: { codeRole: 'admin', labelRole: 'Administrateur' } as any,
+      });
+      mockMembershipRepo.findOne
+        .mockResolvedValueOnce(ownMembership)
+        .mockResolvedValueOnce(adminMembership);
+      await expect(service.changeMemberRole(1, 2, 'member')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockMembershipRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should forbid changing a super_admin member', async () => {
+      const superAdminTarget = makeMembership({
+        idMembership: 2,
+        user: { idUser: 5, email: 'sa@test.com' } as any,
+        role: { codeRole: 'super_admin', labelRole: 'Super Admin' } as any,
+      });
+      mockMembershipRepo.findOne
+        .mockResolvedValueOnce(superAdminTarget)
+        .mockResolvedValueOnce(adminMembership);
+      await expect(service.changeMemberRole(1, 2, 'member')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockMembershipRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the target member does not exist', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(null);
+      await expect(
+        service.changeMemberRole(1, 999, 'instructor'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── expelMember ────────────────────────────────────────────────────────
+  describe('expelMember', () => {
+    const adminMembership = makeMembership({
+      role: { codeRole: 'admin', labelRole: 'Administrateur' } as any,
+    });
+    const targetMembership = makeMembership({
+      idMembership: 2,
+      user: { idUser: 5, email: 'target@test.com' } as any,
+      role: { codeRole: 'member', labelRole: 'Adhérent' } as any,
+    });
+
+    it('should remove the membership when actor is admin of the club', async () => {
+      mockMembershipRepo.findOne
+        .mockResolvedValueOnce(targetMembership)
+        .mockResolvedValueOnce(adminMembership);
+      mockMembershipRepo.remove.mockResolvedValue(undefined);
+
+      const result = await service.expelMember(1, 2);
+      expect(result).toEqual({ success: true });
+      expect(mockMembershipRepo.remove).toHaveBeenCalledWith(targetMembership);
+    });
+
+    it('should throw ForbiddenException when actor is not admin of the club', async () => {
+      mockMembershipRepo.findOne
+        .mockResolvedValueOnce(targetMembership)
+        .mockResolvedValueOnce(null);
+      await expect(service.expelMember(1, 2)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockMembershipRepo.remove).not.toHaveBeenCalled();
+    });
+
+    it('should forbid expelling yourself', async () => {
+      const ownMembership = makeMembership({
+        idMembership: 2,
+        user: { idUser: 1, email: 'me@test.com' } as any,
+        role: { codeRole: 'admin', labelRole: 'Administrateur' } as any,
+      });
+      mockMembershipRepo.findOne
+        .mockResolvedValueOnce(ownMembership)
+        .mockResolvedValueOnce(adminMembership);
+      await expect(service.expelMember(1, 2)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockMembershipRepo.remove).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the target member does not exist', async () => {
+      mockMembershipRepo.findOne.mockResolvedValueOnce(null);
+      await expect(service.expelMember(1, 999)).rejects.toThrow(
         NotFoundException,
       );
     });

--- a/app/backend/src/membership/membership.service.ts
+++ b/app/backend/src/membership/membership.service.ts
@@ -2,12 +2,16 @@ import {
   Injectable,
   ConflictException,
   NotFoundException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Membership } from './membership.entity';
 import { Role } from '../role/role.entity';
 import { LogService } from '../log/log.service';
+
+const ADMIN_ROLES = ['admin', 'super_admin'];
+const ASSIGNABLE_ROLES = ['admin', 'committee', 'instructor', 'member'];
 
 @Injectable()
 export class MembershipService {
@@ -18,6 +22,124 @@ export class MembershipService {
     private readonly roleRepo: Repository<Role>,
     private readonly logService: LogService,
   ) {}
+
+  /**
+   * Verifies the user is an active admin of the targeted club.
+   * Throws ForbiddenException otherwise. Returns the admin membership.
+   */
+  private async assertClubAdmin(
+    actorUserId: number,
+    clubId: number,
+  ): Promise<Membership> {
+    const adminMembership = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: actorUserId },
+        club: { idClub: clubId },
+        status: 'active',
+      },
+      relations: ['role', 'club'],
+    });
+
+    if (
+      !adminMembership ||
+      !ADMIN_ROLES.includes(adminMembership.role.codeRole)
+    ) {
+      throw new ForbiddenException(
+        'Action réservée aux administrateurs de ce club',
+      );
+    }
+
+    return adminMembership;
+  }
+
+  /**
+   * Loads the target membership and verifies the caller is an admin of its club.
+   * Locks actions on one's own membership and on a super_admin.
+   */
+  private async loadTargetAsClubAdmin(
+    actorUserId: number,
+    membershipId: number,
+  ): Promise<Membership> {
+    const target = await this.membershipRepo.findOne({
+      where: { idMembership: membershipId },
+      relations: ['role', 'club', 'user'],
+    });
+
+    if (!target) {
+      throw new NotFoundException('Membre introuvable');
+    }
+
+    await this.assertClubAdmin(actorUserId, target.club.idClub);
+
+    if (target.user.idUser === actorUserId) {
+      throw new ForbiddenException(
+        'Vous ne pouvez pas effectuer cette action sur votre propre adhésion',
+      );
+    }
+
+    if (target.role.codeRole === 'super_admin') {
+      throw new ForbiddenException(
+        'Le rôle super administrateur ne peut pas être modifié',
+      );
+    }
+
+    return target;
+  }
+
+  /**
+   * Changes a member's role. Restricted to admins of the club.
+   */
+  async changeMemberRole(
+    actorUserId: number,
+    membershipId: number,
+    newRoleCode: string,
+  ): Promise<{ success: boolean }> {
+    if (!ASSIGNABLE_ROLES.includes(newRoleCode)) {
+      throw new ForbiddenException('Rôle non assignable');
+    }
+
+    const target = await this.loadTargetAsClubAdmin(actorUserId, membershipId);
+
+    const newRole = await this.roleRepo.findOneBy({ codeRole: newRoleCode });
+    if (!newRole) {
+      throw new NotFoundException('Rôle introuvable');
+    }
+
+    target.role = newRole;
+    await this.membershipRepo.save(target);
+    await this.logService.logMembership({
+      action: 'role_changed',
+      actorId: actorUserId,
+      targetUserId: target.user.idUser,
+      clubId: target.club.idClub,
+    });
+
+    return { success: true };
+  }
+
+  /**
+   * Expels a member from the club (removes the membership, keeps the account).
+   * Restricted to admins of the club.
+   */
+  async expelMember(
+    actorUserId: number,
+    membershipId: number,
+  ): Promise<{ success: boolean }> {
+    const target = await this.loadTargetAsClubAdmin(actorUserId, membershipId);
+
+    const targetUserId = target.user.idUser;
+    const clubId = target.club.idClub;
+
+    await this.membershipRepo.remove(target);
+    await this.logService.logMembership({
+      action: 'member_expelled',
+      actorId: actorUserId,
+      targetUserId,
+      clubId,
+    });
+
+    return { success: true };
+  }
 
   async findMyMembership(userId: number): Promise<Membership | null> {
     return this.membershipRepo.findOne({

--- a/app/frontend/app/components/ui/form-fields.tsx
+++ b/app/frontend/app/components/ui/form-fields.tsx
@@ -170,6 +170,8 @@ type CustomSelectProps = {
   placeholder?: string
   hint?: string
   panelClassName?: string
+  // When false, the empty placeholder option is hidden (value is required).
+  clearable?: boolean
 }
 
 export function CustomSelect({
@@ -181,6 +183,7 @@ export function CustomSelect({
   placeholder = '— Non renseigné —',
   hint,
   panelClassName = 'min-w-[200px]',
+  clearable = true,
 }: CustomSelectProps) {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -237,12 +240,14 @@ export function CustomSelect({
         {isOpen && (
           <div className={`absolute z-50 mt-1 w-full rounded-xl border border-gray-100 bg-white shadow-xl overflow-hidden ${panelClassName}`}>
             <ul className="max-h-64 overflow-y-auto py-1">
-              <li>
-                <button type="button" onClick={() => select('')} className={itemClass('')}>
-                  <span className="w-4 shrink-0" />
-                  <span className="text-gray-400">{placeholder}</span>
-                </button>
-              </li>
+              {clearable && (
+                <li>
+                  <button type="button" onClick={() => select('')} className={itemClass('')}>
+                    <span className="w-4 shrink-0" />
+                    <span className="text-gray-400">{placeholder}</span>
+                  </button>
+                </li>
+              )}
               {options.map((opt) => (
                 <li key={opt.value}>
                   <button type="button" onClick={() => select(opt.value)} className={itemClass(opt.value)}>

--- a/app/frontend/app/dashboard/members/page.tsx
+++ b/app/frontend/app/dashboard/members/page.tsx
@@ -8,9 +8,13 @@ import {
   getPendingRequests,
   acceptRequest,
   rejectRequest,
+  changeMemberRole,
+  expelMember,
   type PendingRequest,
+  type ClubMember,
 } from '@/app/lib/api/membership';
-import { Users, Check, X } from 'lucide-react';
+import { Users, Check, X, UserMinus, AlertTriangle } from 'lucide-react';
+import { CustomSelect } from '@/app/components/ui/form-fields';
 import Link from 'next/link';
 
 const LEVEL_COLORS: Record<string, string> = {
@@ -32,12 +36,21 @@ const ROLE_LABELS: Record<string, string> = {
 
 const ADMIN_ROLES = ['admin', 'super_admin'];
 
+// Roles an admin can assign through the dropdown (super_admin excluded).
+const ASSIGNABLE_ROLES = ['admin', 'committee', 'instructor', 'member'];
+
 export default function MembersPage() {
   const { user, loading: authLoading } = useAuth();
   const { membership, loading: membershipLoading, refetch } = useMembership();
   const router = useRouter();
   const [pendingRequests, setPendingRequests] = useState<PendingRequest[]>([]);
   const [loadingPending, setLoadingPending] = useState(false);
+  // Pending dropdown selection per membership (only set when changed).
+  const [selectedRoles, setSelectedRoles] = useState<Record<number, string>>({});
+  const [savingId, setSavingId] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  // Member awaiting expulsion confirmation in the modal.
+  const [confirmExpel, setConfirmExpel] = useState<ClubMember | null>(null);
 
   useEffect(() => {
     if (!authLoading && !user) router.push('/login');
@@ -71,6 +84,44 @@ export default function MembersPage() {
     const ok = await rejectRequest(membershipId);
     if (ok) {
       setPendingRequests(prev => prev.filter(r => r.idMembership !== membershipId));
+    }
+  };
+
+  // Auto-hide the feedback banner after a few seconds.
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = setTimeout(() => setFeedback(null), 3000);
+    return () => clearTimeout(timeout);
+  }, [feedback]);
+
+  const handleRoleChange = async (membershipId: number) => {
+    const codeRole = selectedRoles[membershipId];
+    if (!codeRole) return;
+    setSavingId(membershipId);
+    const ok = await changeMemberRole(membershipId, codeRole);
+    setSavingId(null);
+    if (ok) {
+      setFeedback('Rôle mis à jour');
+      setSelectedRoles(prev => {
+        const next = { ...prev };
+        delete next[membershipId];
+        return next;
+      });
+      refetch();
+    } else {
+      setFeedback('Échec de la mise à jour du rôle');
+    }
+  };
+
+  const handleExpel = async () => {
+    if (!confirmExpel) return;
+    const ok = await expelMember(confirmExpel.idMembership);
+    setConfirmExpel(null);
+    if (ok) {
+      setFeedback('Membre expulsé');
+      refetch();
+    } else {
+      setFeedback("Échec de l'expulsion");
     }
   };
 
@@ -123,6 +174,12 @@ export default function MembersPage() {
         </p>
       </div>
 
+      {feedback && (
+        <div className="mb-6 bg-[#0d3b66] text-white text-sm font-medium px-4 py-3 rounded-xl shadow">
+          {feedback}
+        </div>
+      )}
+
       {isAdmin && !loadingPending && pendingRequests.length > 0 && (
         <div className="bg-white rounded-2xl shadow-xl overflow-hidden mb-6">
           <div className="px-6 py-4 border-b border-gray-100 flex items-center gap-2">
@@ -174,10 +231,20 @@ export default function MembersPage() {
               <th className="text-left px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide">Membre</th>
               <th className="text-left px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide hidden md:table-cell">Niveau</th>
               <th className="text-left px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide hidden md:table-cell">Rôle</th>
+              {isAdmin && (
+                <th className="text-right px-6 py-4 text-xs font-semibold text-gray-400 uppercase tracking-wide">Actions</th>
+              )}
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
-            {activeMembers.map(member => (
+            {activeMembers.map(member => {
+              // Admins manage other members, but not their own row nor a super_admin.
+              const isOwnRow = member.idMembership === membership.idMembership;
+              const canManage =
+                isAdmin && !isOwnRow && member.role.codeRole !== 'super_admin';
+              const selectedRole = selectedRoles[member.idMembership] ?? member.role.codeRole;
+
+              return (
               <tr key={member.idMembership} className="hover:bg-gray-50 transition-colors">
                 <td className="px-6 py-4">
                   <div className="flex items-center gap-3">
@@ -198,15 +265,93 @@ export default function MembersPage() {
                   </span>
                 </td>
                 <td className="px-6 py-4 hidden md:table-cell">
-                  <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full whitespace-nowrap">
-                    {ROLE_LABELS[member.role.codeRole] ?? member.role.labelRole}
-                  </span>
+                  {canManage ? (
+                    <div className="flex items-center gap-2">
+                      <div className="w-48">
+                        <CustomSelect
+                          value={selectedRole}
+                          onValueChange={v =>
+                            setSelectedRoles(prev => ({
+                              ...prev,
+                              [member.idMembership]: v,
+                            }))
+                          }
+                          options={ASSIGNABLE_ROLES.map(code => ({
+                            value: code,
+                            label: ROLE_LABELS[code],
+                          }))}
+                          clearable={false}
+                        />
+                      </div>
+                      <button
+                        onClick={() => handleRoleChange(member.idMembership)}
+                        disabled={
+                          selectedRole === member.role.codeRole ||
+                          savingId === member.idMembership
+                        }
+                        className="text-sm font-medium px-4 min-h-11 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed bg-[#0d3b66] text-white hover:bg-[#1b6ca8]"
+                      >
+                        Valider
+                      </button>
+                    </div>
+                  ) : (
+                    <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full whitespace-nowrap">
+                      {ROLE_LABELS[member.role.codeRole] ?? member.role.labelRole}
+                    </span>
+                  )}
                 </td>
+                {isAdmin && (
+                  <td className="px-6 py-4 text-right">
+                    {canManage && (
+                      <button
+                        onClick={() => setConfirmExpel(member)}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-red-50 text-red-600 text-sm font-medium rounded-lg hover:bg-red-100 transition-colors"
+                      >
+                        <UserMinus className="w-4 h-4" />
+                        Expulser
+                      </button>
+                    )}
+                  </td>
+                )}
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>
+
+      {confirmExpel && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="bg-white rounded-2xl shadow-xl max-w-md w-full p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-xl bg-red-50 flex items-center justify-center shrink-0">
+                <AlertTriangle className="w-5 h-5 text-red-600" />
+              </div>
+              <h2 className="text-lg font-bold text-[#0d3b66]">Expulser ce membre ?</h2>
+            </div>
+            <p className="text-sm text-gray-500 mb-6">
+              {confirmExpel.user.firstName} {confirmExpel.user.lastName} sera retiré
+              du club. Son compte utilisateur est conservé, mais il devra refaire une
+              demande pour rejoindre le club.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setConfirmExpel(null)}
+                className="px-4 py-2 text-sm font-medium text-gray-500 rounded-lg hover:bg-gray-100 transition-colors"
+              >
+                Annuler
+              </button>
+              <button
+                onClick={handleExpel}
+                className="inline-flex items-center gap-1.5 px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:bg-red-700 transition-colors"
+              >
+                <UserMinus className="w-4 h-4" />
+                Expulser
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
     </div>
   );

--- a/app/frontend/app/lib/api/membership.ts
+++ b/app/frontend/app/lib/api/membership.ts
@@ -146,3 +146,37 @@ export async function rejectRequest(membershipId: number): Promise<boolean> {
     return false;
   }
 }
+
+// Changes a member's role (admin only, scoped to the club).
+export async function changeMemberRole(
+  membershipId: number,
+  codeRole: string,
+): Promise<boolean> {
+  try {
+    const res = await clientFetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/members/${membershipId}/role`,
+      {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ codeRole }),
+      },
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// Expels a member from the club: removes the membership, keeps the account.
+export async function expelMember(membershipId: number): Promise<boolean> {
+  try {
+    const res = await clientFetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/members/${membershipId}`,
+      { method: 'DELETE', credentials: 'include' },
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/app/frontend/tests/members.spec.ts
+++ b/app/frontend/tests/members.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type Page, type BrowserContext } from '@playwright/test';
+
+// Self-contained suite: it registers its own throwaway member, makes them join
+// the club, then exercises the admin actions (role change + expulsion). Nothing
+// from the seed is mutated, so the suite is safe to re-run.
+//
+// Prerequisites: the dev server running and the seeded test database
+// (admin@test.com must be admin of Aquaclub21). The admin password matches the
+// SEED_PASSWORD used to seed the test DB (123 in the existing auth e2e).
+
+const SUFFIX = Date.now();
+const MEMBER_EMAIL = `members-e2e-${SUFFIX}@e2e-test.com`;
+const MEMBER_PASSWORD = 'Test1234!';
+
+const ADMIN_EMAIL = 'admin@test.com';
+const ADMIN_PASSWORD = process.env.SEED_PASSWORD || 'LocalDev_2026!';
+
+const CLUB_SLUG = 'aquaclub21';
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto('/login');
+  await page.getByPlaceholder('vous@exemple.fr').fill(email);
+  await page.getByPlaceholder('••••••••').fill(password);
+  await page.getByRole('button', { name: /se connecter/i }).click();
+  await expect(page).toHaveURL('/dashboard', { timeout: 5000 });
+}
+
+test.describe.serial('Gestion des membres (e2e)', () => {
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+  let memberContext: BrowserContext;
+  let memberPage: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    adminContext = await browser.newContext();
+    adminPage = await adminContext.newPage();
+    memberContext = await browser.newContext();
+    memberPage = await memberContext.newPage();
+  });
+
+  test.afterAll(async () => {
+    await adminContext.close();
+    await memberContext.close();
+  });
+
+  test('un nouveau membre s’inscrit et demande à rejoindre le club', async () => {
+    // Register the throwaway member.
+    await memberPage.goto('/register');
+    await memberPage.getByPlaceholder('Kevin').fill('Playwright');
+    await memberPage.getByPlaceholder('Dupont').fill('Member');
+    await memberPage.getByPlaceholder('vous@exemple.fr').fill(MEMBER_EMAIL);
+    await memberPage.getByPlaceholder('••••••••').fill(MEMBER_PASSWORD);
+    await memberPage.getByRole('button', { name: /créer mon compte/i }).click();
+    await expect(memberPage.getByText('Compte créé avec succès')).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Log in, then request to join the club.
+    await login(memberPage, MEMBER_EMAIL, MEMBER_PASSWORD);
+    await memberPage.goto(`/clubs/${CLUB_SLUG}`);
+    await memberPage
+      .getByRole('button', { name: /demander à rejoindre/i })
+      .click();
+    await expect(
+      memberPage.getByText(/demande en attente de validation/i),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('l’admin accepte la demande d’adhésion', async () => {
+    await login(adminPage, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await adminPage.goto('/dashboard/members');
+
+    // Accept the pending request for the throwaway member.
+    const requestRow = adminPage
+      .locator('div.justify-between')
+      .filter({ hasText: MEMBER_EMAIL });
+    await requestRow.getByRole('button', { name: /accepter/i }).click();
+
+    // The member now appears in the active members table.
+    await expect(
+      adminPage.getByRole('row', { name: MEMBER_EMAIL }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('l’admin change le rôle du membre via le menu + bouton Valider', async () => {
+    const row = adminPage.getByRole('row', { name: MEMBER_EMAIL });
+
+    // The dropdown shows the current role; Valider is disabled until it changes.
+    await row.getByRole('button', { name: 'Adhérent' }).click();
+    await row.getByRole('button', { name: 'Moniteur', exact: true }).click();
+
+    await row.getByRole('button', { name: 'Valider' }).click();
+    await expect(adminPage.getByText('Rôle mis à jour')).toBeVisible({
+      timeout: 5000,
+    });
+    // The dropdown now reflects the new role.
+    await expect(row.getByRole('button', { name: 'Moniteur' })).toBeVisible();
+  });
+
+  test('un non-admin voit la liste en lecture seule', async () => {
+    await memberPage.goto('/dashboard/members');
+
+    // The members list is visible...
+    await expect(
+      memberPage.getByRole('row', { name: MEMBER_EMAIL }),
+    ).toBeVisible({ timeout: 5000 });
+    // ...but no management controls are rendered.
+    await expect(memberPage.getByRole('button', { name: 'Valider' })).toHaveCount(
+      0,
+    );
+    await expect(
+      memberPage.getByRole('button', { name: 'Expulser' }),
+    ).toHaveCount(0);
+  });
+
+  test('l’admin expulse le membre après confirmation', async () => {
+    await adminPage.goto('/dashboard/members');
+    const row = adminPage.getByRole('row', { name: MEMBER_EMAIL });
+
+    await row.getByRole('button', { name: 'Expulser' }).click();
+
+    // Confirm in the modal.
+    await expect(adminPage.getByText('Expulser ce membre ?')).toBeVisible();
+    await adminPage
+      .locator('.fixed.inset-0')
+      .getByRole('button', { name: 'Expulser' })
+      .click();
+
+    await expect(adminPage.getByText('Membre expulsé')).toBeVisible({
+      timeout: 5000,
+    });
+    // The member is gone from the list.
+    await expect(
+      adminPage.getByRole('row', { name: MEMBER_EMAIL }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
- add PATCH /members/:id/role and DELETE /members/:id
  - enforce club-admin authorization in the service (no guard)
  - lock self-edit and super_admin from changes
  - /members UI: role dropdown + Valider button, expel with confirm modal
  - unit tests (service) and Playwright e2e