### PR TITLE
feat(events): member registration with waitlist

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { Club } from './club/club.entity';
 import { AppUser } from './app-user/app-user.entity';
 import { Membership } from './membership/membership.entity';
 import { ClubEvent } from './event/event.entity';
+import { EventRegistration } from './event/event-registration.entity';
 import { ClubModule } from './club/club.module';
 import { AuthModule } from './auth/auth.module';
 import { MembershipModule } from './membership/membership.module';
@@ -28,7 +29,7 @@ const dbEnabled = process.env.DB_ENABLED === 'true';
             username: process.env.DB_USER,
             password: process.env.DB_PASSWORD,
             database: process.env.DB_NAME,
-            entities: [Role, Club, AppUser, Membership, ClubEvent],
+            entities: [Role, Club, AppUser, Membership, ClubEvent, EventRegistration],
             synchronize: false,
             migrationsRun: true,
             migrations: [__dirname + '/database/migrations/*{.ts,.js}'],

--- a/app/backend/src/database/data-source.ts
+++ b/app/backend/src/database/data-source.ts
@@ -7,6 +7,7 @@ import { Club } from '../club/club.entity';
 import { AppUser } from '../app-user/app-user.entity';
 import { Membership } from '../membership/membership.entity';
 import { ClubEvent } from '../event/event.entity';
+import { EventRegistration } from '../event/event-registration.entity';
 
 // Allow CLI commands (migrations, seed) to target a specific env file,
 // e.g. DOTENV_CONFIG_PATH=.env.test for the test database.
@@ -20,7 +21,7 @@ export const AppDataSource = new DataSource({
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
 
-  entities: [Role, Club, AppUser, Membership, ClubEvent],
+  entities: [Role, Club, AppUser, Membership, ClubEvent, EventRegistration],
 
   migrations: [join(__dirname, 'migrations', '*.{ts,js}')],
 

--- a/app/backend/src/database/migrations/1782072597962-CreateEventRegistration.ts
+++ b/app/backend/src/database/migrations/1782072597962-CreateEventRegistration.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateEventRegistration1782072597962
+  implements MigrationInterface
+{
+  name = 'CreateEventRegistration1782072597962';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "event_registration" (
+        "id_registration" SERIAL NOT NULL,
+        "status" character varying(20) NOT NULL,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        "id_event" integer,
+        "id_user" integer,
+        CONSTRAINT "UQ_event_registration_event_user" UNIQUE ("id_event", "id_user"),
+        CONSTRAINT "PK_event_registration" PRIMARY KEY ("id_registration")
+      )
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "event_registration"
+      ADD CONSTRAINT "FK_event_registration_event"
+      FOREIGN KEY ("id_event") REFERENCES "event"("id_event")
+      ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "event_registration"
+      ADD CONSTRAINT "FK_event_registration_user"
+      FOREIGN KEY ("id_user") REFERENCES "app_user"("id_user")
+      ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "event_registration" DROP CONSTRAINT "FK_event_registration_user"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "event_registration" DROP CONSTRAINT "FK_event_registration_event"`,
+    );
+    await queryRunner.query(`DROP TABLE "event_registration"`);
+  }
+}

--- a/app/backend/src/event/event-registration.entity.ts
+++ b/app/backend/src/event/event-registration.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Unique,
+} from 'typeorm';
+import { ClubEvent } from './event.entity';
+import { AppUser } from '../app-user/app-user.entity';
+
+// A user can register only once per event (registered or waitlist).
+@Entity({ name: 'event_registration' })
+@Unique(['event', 'user'])
+export class EventRegistration {
+  @PrimaryGeneratedColumn({ name: 'id_registration' })
+  idRegistration: number;
+
+  @ManyToOne(() => ClubEvent, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'id_event' })
+  event: ClubEvent;
+
+  @ManyToOne(() => AppUser, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'id_user' })
+  user: AppUser;
+
+  // 'registered' | 'waitlist'
+  @Column({ type: 'varchar', length: 20 })
+  status: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/app/backend/src/event/event.controller.ts
+++ b/app/backend/src/event/event.controller.ts
@@ -23,13 +23,28 @@ export class EventController {
   constructor(private readonly eventService: EventService) {}
 
   @Get('clubs/:clubId/events')
-  async findAll(@Param('clubId') clubId: string) {
-    return this.eventService.findAllByClub(parseInt(clubId));
+  async findAll(@Param('clubId') clubId: string, @Req() req: AuthReq) {
+    return this.eventService.findAllByClub(parseInt(clubId), req.user.idUser);
   }
 
   @Get('events/:id')
-  async findOne(@Param('id') id: string) {
-    return this.eventService.findById(parseInt(id));
+  async findOne(@Param('id') id: string, @Req() req: AuthReq) {
+    return this.eventService.findById(parseInt(id), req.user.idUser);
+  }
+
+  @Get('events/:eventId/participants')
+  async participants(@Param('eventId') eventId: string) {
+    return this.eventService.getParticipants(parseInt(eventId));
+  }
+
+  @Post('events/:eventId/register')
+  async register(@Param('eventId') eventId: string, @Req() req: AuthReq) {
+    return this.eventService.register(req.user.idUser, parseInt(eventId));
+  }
+
+  @Delete('events/:eventId/register')
+  async unregister(@Param('eventId') eventId: string, @Req() req: AuthReq) {
+    return this.eventService.unregister(req.user.idUser, parseInt(eventId));
   }
 
   @Post('clubs/:clubId/events')

--- a/app/backend/src/event/event.module.ts
+++ b/app/backend/src/event/event.module.ts
@@ -1,13 +1,17 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ClubEvent } from './event.entity';
+import { EventRegistration } from './event-registration.entity';
 import { Membership } from '../membership/membership.entity';
 import { EventService } from './event.service';
 import { EventController } from './event.controller';
 import { LogModule } from '../log/log.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ClubEvent, Membership]), LogModule],
+  imports: [
+    TypeOrmModule.forFeature([ClubEvent, EventRegistration, Membership]),
+    LogModule,
+  ],
   controllers: [EventController],
   providers: [EventService],
 })

--- a/app/backend/src/event/event.service.spec.ts
+++ b/app/backend/src/event/event.service.spec.ts
@@ -4,8 +4,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ConflictException } from '@nestjs/common';
 import { EventService } from './event.service';
 import { ClubEvent } from './event.entity';
+import { EventRegistration } from './event-registration.entity';
 import { Membership } from '../membership/membership.entity';
 import { LogService } from '../log/log.service';
 
@@ -14,6 +16,14 @@ const mockEventRepo = {
   findOne: jest.fn(),
   find: jest.fn(),
   create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+};
+
+const mockRegistrationRepo = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
   save: jest.fn(),
   remove: jest.fn(),
 };
@@ -53,6 +63,10 @@ describe('EventService', () => {
       providers: [
         EventService,
         { provide: getRepositoryToken(ClubEvent), useValue: mockEventRepo },
+        {
+          provide: getRepositoryToken(EventRegistration),
+          useValue: mockRegistrationRepo,
+        },
         {
           provide: getRepositoryToken(Membership),
           useValue: mockMembershipRepo,
@@ -181,6 +195,154 @@ describe('EventService', () => {
 
       await expect(service.delete(1, 10)).rejects.toThrow(ForbiddenException);
       expect(mockEventRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── register ─────────────────────────────────────────────────────────────
+  describe('register', () => {
+    it('should register an active member when spots remain', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        maxCapacity: 5,
+        club: { idClub: 1 },
+      });
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('member', 1));
+      mockRegistrationRepo.findOne.mockResolvedValue(null); // not yet registered
+      mockRegistrationRepo.count.mockResolvedValue(2); // 2 < 5
+
+      const result = await service.register(1, 10);
+      expect(result.status).toBe('registered');
+      expect(result.message).toBe('Inscription réussie');
+      expect(mockRegistrationRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'registered' }),
+      );
+    });
+
+    it('should waitlist when the event is full', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        maxCapacity: 2,
+        club: { idClub: 1 },
+      });
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('member', 1));
+      mockRegistrationRepo.findOne.mockResolvedValue(null);
+      mockRegistrationRepo.count.mockResolvedValue(2); // full
+
+      const result = await service.register(1, 10);
+      expect(result.status).toBe('waitlist');
+      expect(mockRegistrationRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'waitlist' }),
+      );
+    });
+
+    it('should always register when capacity is unlimited (null)', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        maxCapacity: null,
+        club: { idClub: 1 },
+      });
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('member', 1));
+      mockRegistrationRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.register(1, 10);
+      expect(result.status).toBe('registered');
+      expect(mockRegistrationRepo.count).not.toHaveBeenCalled();
+    });
+
+    it('should forbid a non-member of the club', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        maxCapacity: 5,
+        club: { idClub: 1 },
+      });
+      mockMembershipRepo.findOne.mockResolvedValue(null); // not a member
+
+      await expect(service.register(1, 10)).rejects.toThrow(ForbiddenException);
+      expect(mockRegistrationRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should reject a duplicate registration', async () => {
+      mockEventRepo.findOne.mockResolvedValue({
+        idEvent: 10,
+        maxCapacity: 5,
+        club: { idClub: 1 },
+      });
+      mockMembershipRepo.findOne.mockResolvedValue(makeMembership('member', 1));
+      mockRegistrationRepo.findOne.mockResolvedValue({ idRegistration: 99 });
+
+      await expect(service.register(1, 10)).rejects.toThrow(ConflictException);
+      expect(mockRegistrationRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the event does not exist', async () => {
+      mockEventRepo.findOne.mockResolvedValue(null);
+      await expect(service.register(1, 999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── unregister ───────────────────────────────────────────────────────────
+  describe('unregister', () => {
+    it('should remove the registration and promote the first waitlisted member', async () => {
+      const myReg = {
+        idRegistration: 1,
+        status: 'registered',
+        event: { club: { idClub: 1 } },
+      };
+      const nextInLine = { idRegistration: 2, status: 'waitlist' };
+      mockRegistrationRepo.findOne
+        .mockResolvedValueOnce(myReg) // my registration
+        .mockResolvedValueOnce(nextInLine); // next waitlisted
+
+      const result = await service.unregister(1, 10);
+      expect(result.success).toBe(true);
+      expect(mockRegistrationRepo.remove).toHaveBeenCalledWith(myReg);
+      expect(mockRegistrationRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'registered' }),
+      );
+    });
+
+    it('should not promote anyone when the user was on the waitlist', async () => {
+      const myReg = {
+        idRegistration: 3,
+        status: 'waitlist',
+        event: { club: { idClub: 1 } },
+      };
+      mockRegistrationRepo.findOne.mockResolvedValueOnce(myReg);
+
+      await service.unregister(1, 10);
+      expect(mockRegistrationRepo.remove).toHaveBeenCalledWith(myReg);
+      expect(mockRegistrationRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the user is not registered', async () => {
+      mockRegistrationRepo.findOne.mockResolvedValue(null);
+      await expect(service.unregister(1, 10)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── getParticipants ──────────────────────────────────────────────────────
+  describe('getParticipants', () => {
+    it('should split participants into registered and waitlist', async () => {
+      mockEventRepo.findOne.mockResolvedValue({ idEvent: 10 });
+      mockRegistrationRepo.find.mockResolvedValue([
+        { status: 'registered', user: { firstName: 'A', lastName: 'A' } },
+        { status: 'waitlist', user: { firstName: 'B', lastName: 'B' } },
+        { status: 'registered', user: { firstName: 'C', lastName: 'C' } },
+      ]);
+
+      const result = await service.getParticipants(10);
+      expect(result.registered).toHaveLength(2);
+      expect(result.waitlist).toHaveLength(1);
+      expect(result.registered[0]).toEqual({ firstName: 'A', lastName: 'A' });
+    });
+
+    it('should throw NotFoundException when the event does not exist', async () => {
+      mockEventRepo.findOne.mockResolvedValue(null);
+      await expect(service.getParticipants(999)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/app/backend/src/event/event.service.ts
+++ b/app/backend/src/event/event.service.ts
@@ -2,22 +2,28 @@ import {
   Injectable,
   NotFoundException,
   ForbiddenException,
+  ConflictException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ClubEvent } from './event.entity';
+import { EventRegistration } from './event-registration.entity';
 import { Membership } from '../membership/membership.entity';
 import { CreateEventDto } from './dto/create-event.dto';
 import { UpdateEventDto } from './dto/update-event.dto';
 import { LogService } from '../log/log.service';
 
 const MANAGER_ROLES = ['admin', 'super_admin', 'instructor', 'committee'];
+const REGISTERED = 'registered';
+const WAITLIST = 'waitlist';
 
 @Injectable()
 export class EventService {
   constructor(
     @InjectRepository(ClubEvent)
     private readonly eventRepo: Repository<ClubEvent>,
+    @InjectRepository(EventRegistration)
+    private readonly registrationRepo: Repository<EventRegistration>,
     @InjectRepository(Membership)
     private readonly membershipRepo: Repository<Membership>,
     private readonly logService: LogService,
@@ -45,21 +51,56 @@ export class EventService {
     return membership;
   }
 
-  async findAllByClub(clubId: number): Promise<object[]> {
+  // remainingSpots is null for unlimited capacity (maxCapacity null).
+  private remainingSpots(
+    maxCapacity: number | null,
+    registeredCount: number,
+  ): number | null {
+    if (maxCapacity == null) return null;
+    return Math.max(0, maxCapacity - registeredCount);
+  }
+
+  // Registration figures for one event, from the current user's point of view.
+  private async registrationInfo(
+    eventId: number,
+    maxCapacity: number | null,
+    userId: number,
+  ): Promise<{
+    registeredCount: number;
+    remainingSpots: number | null;
+    userStatus: string | null;
+  }> {
+    const registeredCount = await this.registrationRepo.count({
+      where: { event: { idEvent: eventId }, status: REGISTERED },
+    });
+    const myRegistration = await this.registrationRepo.findOne({
+      where: { event: { idEvent: eventId }, user: { idUser: userId } },
+    });
+    return {
+      registeredCount,
+      remainingSpots: this.remainingSpots(maxCapacity, registeredCount),
+      userStatus: myRegistration ? myRegistration.status : null,
+    };
+  }
+
+  async findAllByClub(clubId: number, userId: number): Promise<object[]> {
     const events = await this.eventRepo.find({
       where: { club: { idClub: clubId } },
       relations: ['creator'],
       order: { startDatetime: 'ASC' },
     });
-    return events.map((e) => ({
-      ...e,
-      creator: e.creator
-        ? { firstName: e.creator.firstName, lastName: e.creator.lastName }
-        : null,
-    }));
+    return Promise.all(
+      events.map(async (e) => ({
+        ...e,
+        creator: e.creator
+          ? { firstName: e.creator.firstName, lastName: e.creator.lastName }
+          : null,
+        ...(await this.registrationInfo(e.idEvent, e.maxCapacity, userId)),
+      })),
+    );
   }
 
-  async findById(eventId: number): Promise<object> {
+  async findById(eventId: number, userId: number): Promise<object> {
     const event = await this.eventRepo.findOne({
       where: { idEvent: eventId },
       relations: ['creator', 'club'],
@@ -68,8 +109,12 @@ export class EventService {
     return {
       ...event,
       creator: event.creator
-        ? { firstName: event.creator.firstName, lastName: event.creator.lastName }
+        ? {
+            firstName: event.creator.firstName,
+            lastName: event.creator.lastName,
+          }
         : null,
+      ...(await this.registrationInfo(eventId, event.maxCapacity, userId)),
     };
   }
 
@@ -147,5 +192,136 @@ export class EventService {
       actorId: userId,
       clubId: event.club.idClub,
     });
+  }
+
+  // Only an active member of the event's club may register.
+  private async assertActiveMember(
+    userId: number,
+    clubId: number,
+  ): Promise<void> {
+    const membership = await this.membershipRepo.findOne({
+      where: {
+        user: { idUser: userId },
+        club: { idClub: clubId },
+        status: 'active',
+      },
+    });
+    if (!membership) {
+      throw new ForbiddenException('Réservé aux membres de ce club');
+    }
+  }
+
+  async register(
+    userId: number,
+    eventId: number,
+  ): Promise<{ status: string; message: string }> {
+    const event = await this.eventRepo.findOne({
+      where: { idEvent: eventId },
+      relations: ['club'],
+    });
+    if (!event) throw new NotFoundException('Événement introuvable');
+
+    await this.assertActiveMember(userId, event.club.idClub);
+
+    const existing = await this.registrationRepo.findOne({
+      where: { event: { idEvent: eventId }, user: { idUser: userId } },
+    });
+    if (existing) {
+      throw new ConflictException('Vous êtes déjà inscrit à cet événement');
+    }
+
+    // Unlimited capacity (maxCapacity null) never goes to the waitlist.
+    let status = REGISTERED;
+    if (event.maxCapacity != null) {
+      const registeredCount = await this.registrationRepo.count({
+        where: { event: { idEvent: eventId }, status: REGISTERED },
+      });
+      if (registeredCount >= event.maxCapacity) status = WAITLIST;
+    }
+
+    await this.registrationRepo.save({
+      event: { idEvent: eventId },
+      user: { idUser: userId },
+      status,
+    });
+
+    await this.logService.logMembership({
+      action: status === REGISTERED ? 'event_registered' : 'event_waitlisted',
+      actorId: userId,
+      clubId: event.club.idClub,
+    });
+
+    return {
+      status,
+      message:
+        status === REGISTERED
+          ? 'Inscription réussie'
+          : 'Événement complet : vous êtes en liste d’attente',
+    };
+  }
+
+  async unregister(
+    userId: number,
+    eventId: number,
+  ): Promise<{ success: boolean; message: string }> {
+    const registration = await this.registrationRepo.findOne({
+      where: { event: { idEvent: eventId }, user: { idUser: userId } },
+      relations: ['event', 'event.club'],
+    });
+    if (!registration) {
+      throw new NotFoundException("Vous n'êtes pas inscrit à cet événement");
+    }
+
+    const freedSpot = registration.status === REGISTERED;
+    const clubId = registration.event.club.idClub;
+    await this.registrationRepo.remove(registration);
+
+    // Promote the first waitlisted member when a registered spot frees up.
+    if (freedSpot) {
+      const nextInLine = await this.registrationRepo.findOne({
+        where: { event: { idEvent: eventId }, status: WAITLIST },
+        order: { createdAt: 'ASC' },
+      });
+      if (nextInLine) {
+        nextInLine.status = REGISTERED;
+        await this.registrationRepo.save(nextInLine);
+      }
+    }
+
+    await this.logService.logMembership({
+      action: 'event_unregistered',
+      actorId: userId,
+      clubId,
+    });
+
+    return { success: true, message: 'Désinscription réussie' };
+  }
+
+  async getParticipants(eventId: number): Promise<{
+    registered: { firstName: string; lastName: string }[];
+    waitlist: { firstName: string; lastName: string }[];
+  }> {
+    const event = await this.eventRepo.findOne({
+      where: { idEvent: eventId },
+    });
+    if (!event) throw new NotFoundException('Événement introuvable');
+
+    const registrations = await this.registrationRepo.find({
+      where: { event: { idEvent: eventId } },
+      relations: ['user'],
+      order: { createdAt: 'ASC' },
+    });
+
+    const toName = (r: EventRegistration) => ({
+      firstName: r.user.firstName,
+      lastName: r.user.lastName,
+    });
+
+    return {
+      registered: registrations
+        .filter((r) => r.status === REGISTERED)
+        .map(toName),
+      waitlist: registrations.filter((r) => r.status === WAITLIST).map(toName),
+    };
   }
 }

--- a/app/frontend/app/components/events/EventCard.tsx
+++ b/app/frontend/app/components/events/EventCard.tsx
@@ -50,11 +50,18 @@ export default function EventCard({ event, isManager, onEdit, onDelete }: Props)
               {event.location}
             </span>
           )}
-          {event.maxCapacity && (
+          {event.remainingSpots != null ? (
             <span className="flex items-center gap-1 text-sm text-gray-400">
               <Users className="w-3.5 h-3.5" />
-              {event.maxCapacity} places
+              {event.remainingSpots} place{event.remainingSpots > 1 ? 's' : ''} restante{event.remainingSpots > 1 ? 's' : ''}
             </span>
+          ) : (
+            event.maxCapacity && (
+              <span className="flex items-center gap-1 text-sm text-gray-400">
+                <Users className="w-3.5 h-3.5" />
+                {event.maxCapacity} places
+              </span>
+            )
           )}
         </div>
       </Link>

--- a/app/frontend/app/dashboard/events/[id]/page.tsx
+++ b/app/frontend/app/dashboard/events/[id]/page.tsx
@@ -5,8 +5,25 @@ import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { useAuth } from '../../../context/AuthContext';
 import { useMembership } from '../../../hooks/useMembership';
 import { useEvents } from '../../../hooks/useEvents';
-import { getEvent, type DashboardEvent } from '@/app/lib/api/events';
-import { ArrowLeft, Calendar, Clock, MapPin, Users, Pencil, Trash2 } from 'lucide-react';
+import {
+  getEvent,
+  getEventParticipants,
+  registerToEvent,
+  unregisterFromEvent,
+  type DashboardEvent,
+  type EventParticipants,
+} from '@/app/lib/api/events';
+import {
+  ArrowLeft,
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  UserPlus,
+  UserMinus,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
 import Link from 'next/link';
 import EventTypeBadge from '../../../components/events/EventTypeBadge';
 import EventDeleteModal from '../../../components/events/EventDeleteModal';
@@ -36,25 +53,69 @@ export default function EventDetailPage() {
   const [eventLoading, setEventLoading] = useState(true);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [toast, setToast] = useState<string | null>(null)
+  const [participants, setParticipants] = useState<EventParticipants>({
+    registered: [],
+    waitlist: [],
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const showToast = (message: string) => {
+    setToast(message);
+    setTimeout(() => setToast(null), 4000);
+  };
+
+  const loadEvent = () => getEvent(eventId).then(setEvent);
+  const loadParticipants = () =>
+    getEventParticipants(eventId).then(setParticipants);
 
   useEffect(() => {
     if (!authLoading && !user) router.push('/login');
   }, [user, authLoading, router]);
 
   useEffect(() => {
-    if (searchParams.get('updated') === '1') {
-      setToast('Événement mis à jour avec succès')
-      setTimeout(() => setToast(null), 4000)
-    }
+    if (searchParams.get('updated') !== '1') return;
+    const show = setTimeout(
+      () => setToast('Événement mis à jour avec succès'),
+      0,
+    );
+    const hide = setTimeout(() => setToast(null), 4000);
+    return () => {
+      clearTimeout(show);
+      clearTimeout(hide);
+    };
   }, [searchParams]);
 
   useEffect(() => {
     if (!eventId) return;
-    getEvent(eventId).then((data) => {
-      setEvent(data);
-      setEventLoading(false);
-    });
+    Promise.all([
+      getEvent(eventId).then(setEvent),
+      getEventParticipants(eventId).then(setParticipants),
+    ]).finally(() => setEventLoading(false));
   }, [eventId]);
+
+  const handleRegister = async () => {
+    setSubmitting(true);
+    const message = await registerToEvent(eventId);
+    setSubmitting(false);
+    if (message) {
+      showToast(message);
+      await Promise.all([loadEvent(), loadParticipants()]);
+    } else {
+      showToast("Échec de l'inscription");
+    }
+  };
+
+  const handleUnregister = async () => {
+    setSubmitting(true);
+    const message = await unregisterFromEvent(eventId);
+    setSubmitting(false);
+    if (message) {
+      showToast(message);
+      await Promise.all([loadEvent(), loadParticipants()]);
+    } else {
+      showToast('Échec de la désinscription');
+    }
+  };
 
   if (authLoading || membershipLoading || eventLoading) {
     return (
@@ -67,6 +128,8 @@ export default function EventDetailPage() {
   if (!user || !event) return null;
 
   const isManager = membership ? MANAGER_ROLES.includes(membership.role.codeRole) : false;
+  const isPast = new Date(event.startDatetime) < new Date();
+  const canParticipate = !!membership && !isPast;
 
   const handleDeleteConfirm = async () => {
     const success = await deleteEvent(event.idEvent);
@@ -200,6 +263,102 @@ export default function EventDetailPage() {
         )}
 
       </div>
+
+      {/* Participation */}
+      {canParticipate && (
+        <div className="bg-white rounded-2xl shadow-sm p-6 mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            {event.userStatus === 'registered' && (
+              <p className="text-sm font-medium text-green-700">✓ Vous êtes inscrit</p>
+            )}
+            {event.userStatus === 'waitlist' && (
+              <p className="text-sm font-medium text-yellow-700">⏳ Vous êtes en liste d’attente</p>
+            )}
+            {event.userStatus == null && event.remainingSpots != null && (
+              <p className="text-sm text-gray-500">
+                {event.remainingSpots > 0
+                  ? `${event.remainingSpots} place${event.remainingSpots > 1 ? 's' : ''} restante${event.remainingSpots > 1 ? 's' : ''}`
+                  : 'Événement complet — inscription en liste d’attente'}
+              </p>
+            )}
+            {event.userStatus == null && event.remainingSpots == null && (
+              <p className="text-sm text-gray-500">Places illimitées</p>
+            )}
+          </div>
+
+          {event.userStatus == null ? (
+            <button
+              onClick={handleRegister}
+              disabled={submitting}
+              className="inline-flex items-center justify-center gap-2 w-full sm:w-auto bg-[#0d3b66] text-white text-sm font-medium px-5 py-2.5 rounded-xl hover:bg-[#1b6ca8] transition-colors disabled:opacity-50"
+            >
+              <UserPlus className="w-4 h-4" />
+              S’inscrire
+            </button>
+          ) : (
+            <button
+              onClick={handleUnregister}
+              disabled={submitting}
+              className="inline-flex items-center justify-center gap-2 w-full sm:w-auto bg-red-50 text-red-600 text-sm font-medium px-5 py-2.5 rounded-xl hover:bg-red-100 transition-colors disabled:opacity-50"
+            >
+              <UserMinus className="w-4 h-4" />
+              Me désinscrire
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Inscrits */}
+      <div className="bg-white rounded-2xl shadow-sm p-6 mt-6">
+        <h2 className="text-base font-semibold text-[#0d3b66] mb-4">
+          Inscrits{' '}
+          <span className="text-gray-400 font-normal">
+            ({participants.registered.length})
+          </span>
+        </h2>
+        {participants.registered.length === 0 ? (
+          <p className="text-sm text-gray-400 text-center py-6">
+            Aucun inscrit pour le moment
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {participants.registered.map((p, i) => (
+              <li key={i} className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-lg bg-[#0d3b66] flex items-center justify-center text-white text-xs font-semibold shrink-0">
+                  {p.firstName?.[0]}{p.lastName?.[0]}
+                </div>
+                <span className="text-sm text-gray-700">
+                  {p.firstName} {p.lastName}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Liste d'attente */}
+      {participants.waitlist.length > 0 && (
+        <div className="bg-white rounded-2xl shadow-sm p-6 mt-6">
+          <h2 className="text-base font-semibold text-[#0d3b66] mb-4">
+            Liste d’attente{' '}
+            <span className="text-gray-400 font-normal">
+              ({participants.waitlist.length})
+            </span>
+          </h2>
+          <ul className="flex flex-col gap-2">
+            {participants.waitlist.map((p, i) => (
+              <li key={i} className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-lg bg-yellow-100 flex items-center justify-center text-yellow-700 text-xs font-semibold shrink-0">
+                  {p.firstName?.[0]}{p.lastName?.[0]}
+                </div>
+                <span className="text-sm text-gray-700">
+                  {p.firstName} {p.lastName}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <EventDeleteModal
         event={showDeleteModal ? event : null}

--- a/app/frontend/app/dashboard/events/page.tsx
+++ b/app/frontend/app/dashboard/events/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '../../context/AuthContext';
 import { useMembership } from '../../hooks/useMembership';
-import { type DashboardEvent } from '@/app/lib/api/events';
+import { getClubEvents, type DashboardEvent } from '@/app/lib/api/events';
 import { useEvents } from '../../hooks/useEvents';
 import { Calendar, Plus } from 'lucide-react';
 import Link from 'next/link';
@@ -21,10 +20,23 @@ export default function EventsPage() {
   const router = useRouter();
 
   const [eventToDelete, setEventToDelete] = useState<DashboardEvent | null>(null);
+  // Enriched events (with remainingSpots) fetched from the club events endpoint.
+  const [events, setEvents] = useState<DashboardEvent[]>([]);
+
+  const clubId = membership?.club.idClub;
+
+  const loadEvents = useCallback(() => {
+    if (!clubId) return;
+    getClubEvents(clubId).then(setEvents);
+  }, [clubId]);
 
   useEffect(() => {
     if (!authLoading && !user) router.push('/login');
   }, [user, authLoading, router]);
+
+  useEffect(() => {
+    loadEvents();
+  }, [loadEvents]);
 
   if (authLoading || membershipLoading) {
     return (
@@ -65,11 +77,11 @@ export default function EventsPage() {
   const isManager = MANAGER_ROLES.includes(membership.role.codeRole);
   const now = new Date();
 
-  const upcoming = membership.club.events
+  const upcoming = events
     .filter(e => new Date(e.startDatetime) >= now)
     .sort((a, b) => +new Date(a.startDatetime) - +new Date(b.startDatetime));
 
-  const past = membership.club.events
+  const past = events
     .filter(e => new Date(e.startDatetime) < now)
     .sort((a, b) => +new Date(b.startDatetime) - +new Date(a.startDatetime));
 
@@ -82,6 +94,7 @@ export default function EventsPage() {
     const success = await deleteEvent(eventToDelete.idEvent);
     if (success) {
       setEventToDelete(null);
+      loadEvents();
       refetch();
     }
   };

--- a/app/frontend/app/lib/api/events.ts
+++ b/app/frontend/app/lib/api/events.ts
@@ -14,6 +14,17 @@ export type DashboardEvent = {
   price: string | null;
   status: string;
   creator: { firstName: string; lastName: string } | null;
+  // Registration info (null remainingSpots = unlimited capacity).
+  remainingSpots?: number | null;
+  registeredCount?: number;
+  userStatus?: 'registered' | 'waitlist' | null;
+};
+
+export type EventParticipant = { firstName: string; lastName: string };
+
+export type EventParticipants = {
+  registered: EventParticipant[];
+  waitlist: EventParticipant[];
 };
 
 export type CreateEventPayload = {
@@ -88,4 +99,67 @@ export async function deleteEvent(eventId: number): Promise<void> {
     },
   );
   if (!res.ok) throw new Error('Erreur lors de la suppression');
+}
+
+// Enriched event list for a club (includes remainingSpots and userStatus).
+export async function getClubEvents(clubId: number): Promise<DashboardEvent[]> {
+  try {
+    const res = await clientFetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/clubs/${clubId}/events`,
+      { cache: 'no-store', credentials: 'include' },
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function getEventParticipants(
+  eventId: number,
+): Promise<EventParticipants> {
+  try {
+    const res = await clientFetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/events/${eventId}/participants`,
+      { cache: 'no-store', credentials: 'include' },
+    );
+    if (!res.ok) return { registered: [], waitlist: [] };
+    return res.json();
+  } catch {
+    return { registered: [], waitlist: [] };
+  }
+}
+
+// Returns the message to show as feedback, or null on failure.
+export async function registerToEvent(eventId: number): Promise<string | null> {
+  try {
+    const res = await clientFetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/events/${eventId}/register`,
+      { method: 'POST', credentials: 'include' },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data.message === 'string' ? data.message : 'Inscription réussie';
+  } catch {
+    return null;
+  }
+}
+
+export async function unregisterFromEvent(
+  eventId: number,
+): Promise<string | null> {
+  try {
+    const res = await clientFetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/events/${eventId}/register`,
+      { method: 'DELETE', credentials: 'include' },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data.message === 'string'
+      ? data.message
+      : 'Désinscription réussie';
+  } catch {
+    return null;
+  }
 }

--- a/app/frontend/tests/auth.spec.ts
+++ b/app/frontend/tests/auth.spec.ts
@@ -3,6 +3,8 @@ import { test, expect } from '@playwright/test';
 const TIMESTAMP = Date.now();
 const TEST_EMAIL = `playwright-${TIMESTAMP}@e2e-test.com`;
 const TEST_PASSWORD = 'Test1234!';
+// Seeded accounts share the SEED_PASSWORD used to seed the DB (123 in CI).
+const SEED_PASSWORD = process.env.SEED_PASSWORD || 'LocalDev_2026!';
 
 test.describe('Authentication', () => {
 
@@ -28,7 +30,7 @@ test.describe('Authentication', () => {
     await page.goto('/login');
 
     await page.getByPlaceholder('vous@exemple.fr').fill('adherent@test.com');
-    await page.getByPlaceholder('••••••••').fill('123');
+    await page.getByPlaceholder('••••••••').fill(SEED_PASSWORD);
 
     await page.getByRole('button', { name: /se connecter/i }).click();
 

--- a/app/frontend/tests/events.spec.ts
+++ b/app/frontend/tests/events.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, type Page, type BrowserContext } from '@playwright/test';
+
+// Self-contained suite for event registration. It creates its own capacity-1
+// event (deleted at the end) and uses three seeded Aquaclub21 accounts:
+// admin (manager), adherent (member A) and moniteur (member B).
+//
+// Prerequisites: dev server running and the seeded database. The shared
+// password is the SEED_PASSWORD used to seed it (LocalDev_2026! by default).
+
+const SUFFIX = Date.now();
+const EVENT_TITLE = `E2E-EVENT-${SUFFIX}`;
+const PASSWORD = process.env.SEED_PASSWORD || 'LocalDev_2026!';
+
+const ADMIN_EMAIL = 'admin@test.com';
+const MEMBER_A_EMAIL = 'adherent@test.com'; // Marc Dupont, member of Aquaclub21
+const MEMBER_A_NAME = 'Marc Dupont';
+const MEMBER_B_EMAIL = 'moniteur@test.com'; // Thomas Dubois, instructor of Aquaclub21
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto('/login');
+  await page.getByPlaceholder('vous@exemple.fr').fill(email);
+  await page.getByPlaceholder('••••••••').fill(password);
+  await page.getByRole('button', { name: /se connecter/i }).click();
+  await expect(page).toHaveURL('/dashboard', { timeout: 5000 });
+}
+
+test.describe.serial('Inscription aux événements (e2e)', () => {
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+  let aContext: BrowserContext;
+  let aPage: Page;
+  let bContext: BrowserContext;
+  let bPage: Page;
+  let eventUrl: string;
+
+  test.beforeAll(async ({ browser }) => {
+    adminContext = await browser.newContext();
+    adminPage = await adminContext.newPage();
+    aContext = await browser.newContext();
+    aPage = await aContext.newPage();
+    bContext = await browser.newContext();
+    bPage = await bContext.newPage();
+  });
+
+  test.afterAll(async () => {
+    // Best-effort cleanup: delete the test event (cascades registrations).
+    try {
+      if (eventUrl) {
+        await adminPage.goto(eventUrl);
+        await adminPage.getByRole('button', { name: 'Supprimer' }).first().click();
+        await adminPage
+          .locator('.fixed.inset-0')
+          .getByRole('button', { name: 'Supprimer' })
+          .click();
+      }
+    } catch {
+      // ignore cleanup failures
+    }
+    await adminContext.close();
+    await aContext.close();
+    await bContext.close();
+  });
+
+  test('un manager crée un événement à capacité 1', async () => {
+    await login(adminPage, ADMIN_EMAIL, PASSWORD);
+    await adminPage.goto('/dashboard/events/create');
+
+    await adminPage
+      .getByPlaceholder('Ex : Sortie lac de Nantua')
+      .fill(EVENT_TITLE);
+    await adminPage
+      .locator('input[name="startDatetime"]')
+      .fill('2027-01-10T10:00');
+    await adminPage.locator('input[name="endDatetime"]').fill('2027-01-10T12:00');
+    await adminPage.getByPlaceholder('Ex : 12').fill('1');
+    await adminPage.getByRole('button', { name: "Créer l'événement" }).click();
+
+    await expect(adminPage).toHaveURL('/dashboard/events', { timeout: 5000 });
+
+    // Open the created event to capture its detail URL.
+    await adminPage.getByText(EVENT_TITLE).click();
+    await adminPage.waitForURL(/\/dashboard\/events\/\d+$/);
+    eventUrl = adminPage.url();
+  });
+
+  test('le premier membre s’inscrit (place disponible)', async () => {
+    await login(aPage, MEMBER_A_EMAIL, PASSWORD);
+    await aPage.goto(eventUrl);
+
+    await aPage.getByRole('button', { name: /^S.inscrire$/ }).click();
+    await expect(aPage.getByText('Inscription réussie')).toBeVisible({
+      timeout: 5000,
+    });
+    // Member A now shows as registered.
+    await expect(aPage.getByText(/Vous êtes inscrit/)).toBeVisible();
+    await expect(aPage.getByText(MEMBER_A_NAME)).toBeVisible();
+  });
+
+  test('le second membre passe en liste d’attente (événement complet)', async () => {
+    await login(bPage, MEMBER_B_EMAIL, PASSWORD);
+    await bPage.goto(eventUrl);
+
+    await bPage.getByRole('button', { name: /^S.inscrire$/ }).click();
+    await expect(bPage.getByText(/liste d.attente/i)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('la désinscription promeut le premier en liste d’attente', async () => {
+    // Member A unregisters, freeing the single spot.
+    await aPage.getByRole('button', { name: /Me désinscrire/ }).click();
+    await expect(aPage.getByText('Désinscription réussie')).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Member B reloads: promoted from waitlist to registered.
+    await bPage.goto(eventUrl);
+    await expect(bPage.getByText(/Vous êtes inscrit/)).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(
+      bPage.getByRole('button', { name: /Me désinscrire/ }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
  - add event_registration table (migration) + entity
  - POST/DELETE /events/:id/register and GET /events/:id/participants
  - waitlist when full, auto-promote first in line on unregister
  - unlimited capacity (maxCapacity null) never waitlists
  - expose remainingSpots and userStatus in event list/detail
  - /events list shows "X places restantes"
  - event detail: register/unregister + Inscrits/Liste d'attente blocks
  - unit tests (service) and Playwright e2e