### PR TITLE
fix(logs): decouple LogService from MongoDB to unblock boot

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -14,16 +14,15 @@ import { Payment } from './payment/payment.entity';
 import { ClubModule } from './club/club.module';
 import { AuthModule } from './auth/auth.module';
 import { MembershipModule } from './membership/membership.module';
-import { MongooseModule } from '@nestjs/mongoose';
 import { EventModule } from './event/event.module';
 import { LogModule } from './log/log.module';
 
 const dbEnabled = process.env.DB_ENABLED === 'true';
 
 /**
- * Root application module. Wires the PostgreSQL (TypeORM) and MongoDB (Mongoose)
- * connections and registers every feature module. Database wiring is gated by
- * the DB_ENABLED flag (migrations run automatically on boot).
+ * Root application module. Wires the PostgreSQL (TypeORM) connection and
+ * registers every feature module. Database wiring is gated by the DB_ENABLED
+ * flag (migrations run automatically on boot).
  */
 @Module({
   imports: [
@@ -53,7 +52,6 @@ const dbEnabled = process.env.DB_ENABLED === 'true';
           ClubModule,
           AuthModule,
           MembershipModule,
-          MongooseModule.forRoot(process.env.MONGO_URL ?? ''),
           LogModule,
           EventModule,
         ]

--- a/app/backend/src/log/log.module.ts
+++ b/app/backend/src/log/log.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
-import { Log, LogSchema } from './schemas/log.schema';
 import { LogService } from './log.service';
 
-/** Logging module: exposes {@link LogService}, backed by the Mongo `logs` collection. */
+/**
+ * Logging module: exposes {@link LogService}. Logs are written to the
+ * application logger (console). The Mongo-backed implementation is kept in
+ * `schemas/log.schema.ts` for a future re-enable.
+ */
 @Module({
-  imports: [MongooseModule.forFeature([{ name: Log.name, schema: LogSchema }])],
   providers: [LogService],
   exports: [LogService],
 })

--- a/app/backend/src/log/log.service.ts
+++ b/app/backend/src/log/log.service.ts
@@ -1,20 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
-import { Log, LogDocument } from './schemas/log.schema';
 
 /**
- * Audit logging to MongoDB. Each helper writes a typed entry (auth, membership
- * or error). Writes are best-effort: failures are caught and logged locally,
- * never propagated — logging can never break a request.
+ * Audit logging. Each helper writes a typed entry (auth, membership or error)
+ * to the application logger. Writes are best-effort and never propagate —
+ * logging can never break a request.
+ *
+ * The previous Mongo-backed implementation is preserved in
+ * `schemas/log.schema.ts`; re-wire `MongooseModule` and inject the model here
+ * to restore persistent audit logs.
  */
 @Injectable()
 export class LogService {
   private readonly logger = new Logger(LogService.name);
-
-  constructor(
-    @InjectModel(Log.name) private readonly logModel: Model<LogDocument>,
-  ) {}
 
   /** Record an authentication event (register, login success/failure, logout). */
   async logAuth(data: {
@@ -23,11 +20,7 @@ export class LogService {
     email?: string;
     ip?: string;
   }): Promise<void> {
-    try {
-      await this.logModel.create({ type: 'auth', ...data });
-    } catch (err) {
-      this.logger.error('Failed to write auth log', err);
-    }
+    this.logger.log(`auth ${JSON.stringify(data)}`);
   }
 
   /** Record a membership or event action (request, role change, registration…). */
@@ -38,15 +31,7 @@ export class LogService {
     clubId?: number;
     clubName?: string;
   }): Promise<void> {
-    try {
-      await this.logModel.create({
-        type: 'membership',
-        userId: data.actorId,
-        ...data,
-      });
-    } catch (err) {
-      this.logger.error('Failed to write membership log', err);
-    }
+    this.logger.log(`membership ${JSON.stringify(data)}`);
   }
 
   /** Record a handled error (status code, endpoint, message). */
@@ -56,10 +41,6 @@ export class LogService {
     message: string;
     userId?: number;
   }): Promise<void> {
-    try {
-      await this.logModel.create({ type: 'error', ...data });
-    } catch (err) {
-      this.logger.error('Failed to write error log', err);
-    }
+    this.logger.log(`error ${JSON.stringify(data)}`);
   }
 }

--- a/app/frontend/tests/events.spec.ts
+++ b/app/frontend/tests/events.spec.ts
@@ -101,9 +101,13 @@ test.describe.serial('Inscription aux événements (e2e)', () => {
     await bPage.goto(eventUrl);
 
     await bPage.getByRole('button', { name: /^S.inscrire$/ }).click();
-    await expect(bPage.getByText(/liste d.attente/i)).toBeVisible({
-      timeout: 5000,
-    });
+    // Target B's own waitlist status (the ⏳ marker is unique to it — avoids
+    // matching the toast and the "Liste d’attente (n)" heading).
+    await expect(bPage.getByText(/⏳ Vous êtes en liste d.attente/i)).toBeVisible(
+      {
+        timeout: 5000,
+      },
+    );
   });
 
   test('la désinscription promeut le premier en liste d’attente', async () => {


### PR DESCRIPTION
Backend crash-looped on Mongo auth failure (502 in prod). Drop the Mongoose wiring (forRoot/forFeature) and write audit logs to the app logger instead. Log schema kept for a future re-enable.