### PR TITLE
feat(auth): add show/hide password toggle on login, register and profile

### DIFF
--- a/app/frontend/app/components/profile/ChangePasswordModal.tsx
+++ b/app/frontend/app/components/profile/ChangePasswordModal.tsx
@@ -85,10 +85,10 @@ export function ChangePasswordModal({ onClose, onSuccess }: Props) {
           <PasswordField
             value={current}
             onChange={(e) => { setCurrent(e.target.value); setWrongCurrent(false) }}
-            className={`w-full rounded-lg border pl-4 pr-10 py-3 text-sm text-gray-800 outline-none transition min-h-11
+            className={`w-full rounded-lg border px-4 py-3 text-sm text-gray-800 outline-none transition min-h-11
               focus:border-[#3DA9FC] focus:ring-2 focus:ring-[#3DA9FC]/20
               ${wrongCurrent ? 'border-red-400 bg-red-50' : 'border-gray-200 bg-white hover:border-gray-300'}`}
-            toggleClassName="hover:text-[#3DA9FC]"
+            toggleClassName="rounded-lg border border-gray-200 hover:text-[#3DA9FC] hover:border-gray-300"
             placeholder="••••••••"
           />
           {wrongCurrent && (
@@ -102,9 +102,9 @@ export function ChangePasswordModal({ onClose, onSuccess }: Props) {
           <PasswordField
             value={newPwd}
             onChange={(e) => setNewPwd(e.target.value)}
-            className="w-full rounded-lg border border-gray-200 bg-white pl-4 pr-10 py-3 text-sm text-gray-800 outline-none transition min-h-11
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-800 outline-none transition min-h-11
               focus:border-[#3DA9FC] focus:ring-2 focus:ring-[#3DA9FC]/20 hover:border-gray-300"
-            toggleClassName="hover:text-[#3DA9FC]"
+            toggleClassName="rounded-lg border border-gray-200 hover:text-[#3DA9FC] hover:border-gray-300"
             placeholder="••••••••"
           />
         </div>
@@ -115,9 +115,9 @@ export function ChangePasswordModal({ onClose, onSuccess }: Props) {
           <PasswordField
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
-            className="w-full rounded-lg border border-gray-200 bg-white pl-4 pr-10 py-3 text-sm text-gray-800 outline-none transition min-h-11
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-800 outline-none transition min-h-11
               focus:border-[#3DA9FC] focus:ring-2 focus:ring-[#3DA9FC]/20 hover:border-gray-300"
-            toggleClassName="hover:text-[#3DA9FC]"
+            toggleClassName="rounded-lg border border-gray-200 hover:text-[#3DA9FC] hover:border-gray-300"
             placeholder="••••••••"
           />
         </div>

--- a/app/frontend/app/components/ui/Input.tsx
+++ b/app/frontend/app/components/ui/Input.tsx
@@ -15,7 +15,7 @@ type InputProps = {
 
 export default function Input({ name, type = 'text', value, onChange, placeholder, icon: Icon, error, hint, label }: InputProps) {
   const isPassword = type === 'password';
-  const inputClassName = `w-full ${Icon ? 'pl-10' : 'pl-4'} ${isPassword ? 'pr-10' : 'pr-4'} py-3 rounded-xl border text-sm focus:outline-none focus:ring-2 focus:ring-[#00b4d8] ${error ? 'border-red-400' : 'border-gray-200'}`;
+  const inputClassName = `w-full ${Icon ? 'pl-10' : 'pl-4'} pr-4 py-3 rounded-xl border text-sm focus:outline-none focus:ring-2 focus:ring-[#00b4d8] ${error ? 'border-red-400' : 'border-gray-200'}`;
 
   return (
     <div>

--- a/app/frontend/app/components/ui/PasswordField.tsx
+++ b/app/frontend/app/components/ui/PasswordField.tsx
@@ -13,8 +13,9 @@ type PasswordFieldProps = {
   toggleClassName?: string;
 };
 
-// A password input bundled with a show/hide eye toggle.
-// Styling is left to the caller through `className` so it fits any form chrome.
+// A password input paired with a show/hide toggle placed *next to* the field
+// (not overlaid) so the eye button keeps its own tap target on touch screens.
+// Styling is left to the caller through `className` / `toggleClassName`.
 export default function PasswordField({
   name,
   value,
@@ -22,29 +23,31 @@ export default function PasswordField({
   placeholder,
   icon: Icon,
   className,
-  toggleClassName = 'hover:text-[#006994]',
+  toggleClassName = 'rounded-xl border border-gray-200 hover:text-[#006994] hover:border-gray-300',
 }: PasswordFieldProps) {
   const [show, setShow] = useState(false);
 
   return (
-    <div className="relative">
-      {Icon && <Icon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />}
-      <input
-        name={name}
-        type={show ? 'text' : 'password'}
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        className={className}
-      />
+    <div className="flex items-stretch gap-2">
+      <div className="relative flex-1">
+        {Icon && <Icon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />}
+        <input
+          name={name}
+          type={show ? 'text' : 'password'}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          className={className}
+        />
+      </div>
       <button
         type="button"
         onClick={() => setShow((prev) => !prev)}
-        className={`absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors ${toggleClassName}`}
+        className={`shrink-0 flex items-center justify-center px-3.5 text-gray-400 transition-colors ${toggleClassName}`}
         aria-label={show ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
         aria-pressed={show}
       >
-        {show ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+        {show ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
       </button>
     </div>
   );


### PR DESCRIPTION
Add a PasswordField UI component bundling a show/hide eye toggle placed next to the input (not overlaid) for reliable tap targets on mobile. Reused by the shared Input component (login, register) and the change password modal (current, new, confirm fields).