### PR TITLE
Feature/rgpd

### DIFF
--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import {
   Post,
   Put,
   Patch,
+  Delete,
   Body,
   Req,
   Res,
@@ -77,6 +78,34 @@ export class AuthController {
   @ApiResponse({ status: 401, description: 'Missing or invalid token.' })
   me(@Req() req: AuthenticatedRequest) {
     return this.authService.me(req.user.idUser);
+  }
+
+  /** Export the authenticated user's personal data as JSON (GDPR). */
+  @Get('me/export')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({ summary: 'Export the current user personal data (GDPR)' })
+  @ApiResponse({ status: 200, description: 'JSON export of personal data.' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid token.' })
+  exportMyData(@Req() req: AuthenticatedRequest) {
+    return this.authService.exportMyData(req.user.idUser);
+  }
+
+  /** Delete (anonymize + soft delete) the authenticated user's account (GDPR). */
+  @Delete('me')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({ summary: 'Delete the current account (GDPR right to erasure)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Account anonymized and deleted; the cookie is cleared.',
+  })
+  @ApiResponse({ status: 401, description: 'Missing or invalid token.' })
+  deleteMe(
+    @Req() req: AuthenticatedRequest,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    return this.authService.deleteMe(req.user.idUser, res);
   }
 
   /** Update the authenticated user's profile. */

--- a/app/backend/src/auth/auth.module.ts
+++ b/app/backend/src/auth/auth.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { User } from '../user/user.entity';
+import { Membership } from '../membership/membership.entity';
+import { EventRegistration } from '../event/event-registration.entity';
+import { Certificate } from '../certificate/certificate.entity';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
@@ -13,7 +16,12 @@ import { LogModule } from '../log/log.module';
  */
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([
+      User,
+      Membership,
+      EventRegistration,
+      Certificate,
+    ]),
     JwtModule.register({
       secret: process.env.JWT_SECRET ?? 'diving-o-club-secret',
       signOptions: { expiresIn: '7d' },

--- a/app/backend/src/auth/auth.service.ts
+++ b/app/backend/src/auth/auth.service.ts
@@ -10,6 +10,9 @@ import { JwtService } from '@nestjs/jwt';
 import { Response } from 'express';
 import * as argon2 from 'argon2';
 import { User } from '../user/user.entity';
+import { Membership } from '../membership/membership.entity';
+import { EventRegistration } from '../event/event-registration.entity';
+import { Certificate } from '../certificate/certificate.entity';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { LogService } from '../log/log.service';
@@ -27,6 +30,12 @@ export class AuthService {
   constructor(
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
+    @InjectRepository(Membership)
+    private readonly membershipRepo: Repository<Membership>,
+    @InjectRepository(EventRegistration)
+    private readonly registrationRepo: Repository<EventRegistration>,
+    @InjectRepository(Certificate)
+    private readonly certificateRepo: Repository<Certificate>,
     private readonly jwtService: JwtService,
     private readonly logService: LogService,
   ) {}
@@ -148,5 +157,111 @@ export class AuthService {
       instructorLevel: dto.instructorLevel,
     });
     return this.userRepo.findOneByOrFail({ idUser: userId });
+  }
+
+  /**
+   * Anonymize and soft-delete the account (GDPR right to erasure). Identifying
+   * fields are wiped, medical certificates (health data) are removed, then the
+   * row is soft-deleted so TypeORM excludes it from every `find()` while keeping
+   * the `RESTRICT` relations (memberships, registrations) intact for club data
+   * integrity. The session cookie is cleared on the way out.
+   */
+  async deleteMe(
+    userId: number,
+    res: Response,
+  ): Promise<{ message: string }> {
+    await this.userRepo.update(userId, {
+      email: `deleted_${userId}@deleted.local`,
+      firstName: 'Compte',
+      lastName: 'supprimé',
+      phone: null,
+      birthDate: null,
+      street: null,
+      postalCode: null,
+      city: null,
+      ffessmLicenseNumber: null,
+      divingLevel: null,
+      instructorLevel: null,
+      profilePictureUrl: null,
+    });
+
+    // Medical certificates are health data: remove them on account deletion.
+    await this.certificateRepo
+      .createQueryBuilder()
+      .delete()
+      .where('id_user = :userId', { userId })
+      .execute();
+
+    await this.userRepo.softDelete(userId);
+
+    res.clearCookie('access_token');
+    return { message: 'Compte supprimé' };
+  }
+
+  /**
+   * Build a portable JSON copy of the user's personal data (GDPR right to
+   * access/portability): identity, diving profile, memberships, event
+   * registrations and certificates. The password hash, soft-delete marker and
+   * stored file references are deliberately excluded.
+   */
+  async exportMyData(userId: number) {
+    const user = await this.userRepo.findOneByOrFail({ idUser: userId });
+
+    const memberships = await this.membershipRepo.find({
+      where: { user: { idUser: userId } },
+      relations: { club: true, role: true },
+    });
+    const registrations = await this.registrationRepo.find({
+      where: { user: { idUser: userId } },
+      relations: { event: true },
+    });
+    const certificates = await this.certificateRepo.find({
+      where: { user: { idUser: userId } },
+    });
+
+    return {
+      exportedAt: new Date().toISOString(),
+      identity: {
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        birthDate: user.birthDate,
+        phone: user.phone,
+        address: {
+          street: user.street,
+          postalCode: user.postalCode,
+          city: user.city,
+        },
+      },
+      diving: {
+        ffessmLicenseNumber: user.ffessmLicenseNumber,
+        divingLevel: user.divingLevel,
+        instructorLevel: user.instructorLevel,
+      },
+      account: {
+        createdAt: user.createdAt,
+      },
+      memberships: memberships.map((m) => ({
+        club: m.club?.name ?? null,
+        role: m.role?.codeRole ?? null,
+        season: m.season,
+        status: m.status,
+        membershipDate: m.membershipDate,
+        decisionDate: m.decisionDate,
+      })),
+      registrations: registrations.map((r) => ({
+        event: r.event?.title ?? null,
+        date: r.event?.startDatetime ?? null,
+        location: r.event?.location ?? null,
+        status: r.status,
+        registeredAt: r.createdAt,
+      })),
+      certificates: certificates.map((c) => ({
+        issueDate: c.issueDate,
+        expirationDate: c.expirationDate,
+        status: c.status,
+        depositAt: c.depositAt,
+      })),
+    };
   }
 }

--- a/app/backend/src/club/club.service.ts
+++ b/app/backend/src/club/club.service.ts
@@ -38,6 +38,15 @@ export class ClubService {
       throw new NotFoundException(`Club "${slug}" not found`);
     }
 
+    // This endpoint is public: exclude soft-deleted members (their `user` relation
+    // resolves to null, GDPR) and never expose any member's password hash.
+    club.memberships = club.memberships
+      .filter((m) => m.user)
+      .map((m) => {
+        const { passwordHash: _pw, ...safeUser } = m.user;
+        return { ...m, user: safeUser };
+      }) as Club['memberships'];
+
     return club;
   }
 }

--- a/app/backend/src/event/event.service.spec.ts
+++ b/app/backend/src/event/event.service.spec.ts
@@ -22,12 +22,23 @@ const mockEventRepo = {
   remove: jest.fn(),
 };
 
+// Chainable query builder used by countActiveRegistered and waitlist promotion.
+const mockQueryBuilder = {
+  innerJoin: jest.fn(),
+  where: jest.fn(),
+  andWhere: jest.fn(),
+  orderBy: jest.fn(),
+  getCount: jest.fn(),
+  getOne: jest.fn(),
+};
+
 const mockRegistrationRepo = {
   findOne: jest.fn(),
   find: jest.fn(),
   count: jest.fn(),
   save: jest.fn(),
   remove: jest.fn(),
+  createQueryBuilder: jest.fn(),
 };
 
 const mockMembershipRepo = {
@@ -81,6 +92,13 @@ describe('EventService', () => {
 
     service = module.get<EventService>(EventService);
     jest.clearAllMocks();
+
+    // Re-wire the chainable query builder after the reset.
+    mockQueryBuilder.innerJoin.mockReturnThis();
+    mockQueryBuilder.where.mockReturnThis();
+    mockQueryBuilder.andWhere.mockReturnThis();
+    mockQueryBuilder.orderBy.mockReturnThis();
+    mockRegistrationRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder);
   });
 
   // ── create ───────────────────────────────────────────────────────────────
@@ -212,7 +230,7 @@ describe('EventService', () => {
       });
       mockMembershipRepo.findOne.mockResolvedValue(makeMembership('member', 1));
       mockRegistrationRepo.findOne.mockResolvedValue(null); // not yet registered
-      mockRegistrationRepo.count.mockResolvedValue(2); // 2 < 5
+      mockQueryBuilder.getCount.mockResolvedValue(2); // 2 < 5
 
       const result = await service.register(1, 10);
       expect(result.status).toBe('registered');
@@ -230,7 +248,7 @@ describe('EventService', () => {
       });
       mockMembershipRepo.findOne.mockResolvedValue(makeMembership('member', 1));
       mockRegistrationRepo.findOne.mockResolvedValue(null);
-      mockRegistrationRepo.count.mockResolvedValue(2); // full
+      mockQueryBuilder.getCount.mockResolvedValue(2); // full
 
       const result = await service.register(1, 10);
       expect(result.status).toBe('waitlist');
@@ -250,7 +268,7 @@ describe('EventService', () => {
 
       const result = await service.register(1, 10);
       expect(result.status).toBe('registered');
-      expect(mockRegistrationRepo.count).not.toHaveBeenCalled();
+      expect(mockRegistrationRepo.createQueryBuilder).not.toHaveBeenCalled();
     });
 
     it('should forbid a non-member of the club', async () => {
@@ -293,9 +311,8 @@ describe('EventService', () => {
         event: { club: { idClub: 1 } },
       };
       const nextInLine = { idRegistration: 2, status: 'waitlist' };
-      mockRegistrationRepo.findOne
-        .mockResolvedValueOnce(myReg) // my registration
-        .mockResolvedValueOnce(nextInLine); // next waitlisted
+      mockRegistrationRepo.findOne.mockResolvedValue(myReg); // my registration
+      mockQueryBuilder.getOne.mockResolvedValue(nextInLine); // next waitlisted
 
       const result = await service.unregister(1, 10);
       expect(result.success).toBe(true);

--- a/app/backend/src/event/event.service.ts
+++ b/app/backend/src/event/event.service.ts
@@ -67,6 +67,18 @@ export class EventService {
     return Math.max(0, maxCapacity - registeredCount);
   }
 
+  // Count an event's REGISTERED entries, excluding soft-deleted users: the
+  // inner join on `user` carries TypeORM's `deleted_at IS NULL` condition, so a
+  // deleted member no longer occupies a spot.
+  private countActiveRegistered(eventId: number): Promise<number> {
+    return this.registrationRepo
+      .createQueryBuilder('registration')
+      .innerJoin('registration.user', 'user')
+      .where('registration.id_event = :eventId', { eventId })
+      .andWhere('registration.status = :status', { status: REGISTERED })
+      .getCount();
+  }
+
   // Registration figures for one event, from the current user's point of view.
   private async registrationInfo(
     eventId: number,
@@ -77,9 +89,7 @@ export class EventService {
     remainingSpots: number | null;
     userStatus: string | null;
   }> {
-    const registeredCount = await this.registrationRepo.count({
-      where: { event: { idEvent: eventId }, status: REGISTERED },
-    });
+    const registeredCount = await this.countActiveRegistered(eventId);
     const myRegistration = await this.registrationRepo.findOne({
       where: { event: { idEvent: eventId }, user: { idUser: userId } },
     });
@@ -252,9 +262,7 @@ export class EventService {
     // Unlimited capacity (maxCapacity null) never goes to the waitlist.
     let status = REGISTERED;
     if (event.maxCapacity != null) {
-      const registeredCount = await this.registrationRepo.count({
-        where: { event: { idEvent: eventId }, status: REGISTERED },
-      });
+      const registeredCount = await this.countActiveRegistered(eventId);
       if (registeredCount >= event.maxCapacity) status = WAITLIST;
     }
 
@@ -299,12 +307,16 @@ export class EventService {
     const clubId = registration.event.club.idClub;
     await this.registrationRepo.remove(registration);
 
-    // Promote the first waitlisted member when a registered spot frees up.
+    // Promote the first waitlisted member when a registered spot frees up. The
+    // inner join on `user` skips soft-deleted accounts so they are not promoted.
     if (freedSpot) {
-      const nextInLine = await this.registrationRepo.findOne({
-        where: { event: { idEvent: eventId }, status: WAITLIST },
-        order: { createdAt: 'ASC' },
-      });
+      const nextInLine = await this.registrationRepo
+        .createQueryBuilder('registration')
+        .innerJoin('registration.user', 'user')
+        .where('registration.id_event = :eventId', { eventId })
+        .andWhere('registration.status = :status', { status: WAITLIST })
+        .orderBy('registration.registration_at', 'ASC')
+        .getOne();
       if (nextInLine) {
         nextInLine.status = REGISTERED;
         await this.registrationRepo.save(nextInLine);
@@ -341,11 +353,13 @@ export class EventService {
       lastName: r.user.lastName,
     });
 
+    // Drop registrations whose user was soft-deleted (GDPR): their `user`
+    // relation resolves to null and they must no longer appear among participants.
+    const visible = registrations.filter((r) => r.user);
+
     return {
-      registered: registrations
-        .filter((r) => r.status === REGISTERED)
-        .map(toName),
-      waitlist: registrations.filter((r) => r.status === WAITLIST).map(toName),
+      registered: visible.filter((r) => r.status === REGISTERED).map(toName),
+      waitlist: visible.filter((r) => r.status === WAITLIST).map(toName),
     };
   }
 }

--- a/app/backend/src/membership/membership.controller.ts
+++ b/app/backend/src/membership/membership.controller.ts
@@ -52,10 +52,14 @@ export class MembershipController {
       user: safeUser,
       club: {
         ...membership.club,
-        memberships: membership.club.memberships.map((m) => {
-          const { passwordHash: _pw2, ...safeU } = m.user;
-          return { ...m, user: safeU };
-        }),
+        // Skip memberships whose user was soft-deleted (GDPR): their `user`
+        // relation resolves to null, so they must not appear in the list.
+        memberships: membership.club.memberships
+          .filter((m) => m.user)
+          .map((m) => {
+            const { passwordHash: _pw2, ...safeU } = m.user;
+            return { ...m, user: safeU };
+          }),
       },
     };
   }

--- a/app/backend/src/membership/membership.service.ts
+++ b/app/backend/src/membership/membership.service.ts
@@ -318,10 +318,12 @@ export class MembershipService {
       relations: ['user'],
     });
 
-    return memberships.map((m) => {
-      const { passwordHash: _pw, ...safeUser } = m.user;
-      return { ...m, user: safeUser };
-    }) as Membership[];
+    return memberships
+      .filter((m) => m.user)
+      .map((m) => {
+        const { passwordHash: _pw, ...safeUser } = m.user;
+        return { ...m, user: safeUser };
+      }) as Membership[];
   }
 
   /** Approve a pending request: set it active and stamp the decision date. */

--- a/app/frontend/app/cgu/page.tsx
+++ b/app/frontend/app/cgu/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import LegalPage, { LegalSection } from '../components/legal/LegalPage';
+
+export const metadata: Metadata = {
+  title: "Conditions générales d'utilisation — Diving O Club",
+  description: "Conditions générales d'utilisation de la plateforme Diving O Club.",
+};
+
+export default function CguPage() {
+  return (
+    <LegalPage
+      title="Conditions générales d'utilisation"
+      updatedAt="24 juin 2026"
+      intro={
+        <p>
+          Les présentes conditions générales d&apos;utilisation (CGU) encadrent
+          l&apos;accès et l&apos;usage de la plateforme Diving O Club. En créant un
+          compte, vous acceptez ces conditions.
+        </p>
+      }
+    >
+      <LegalSection title="1. Objet">
+        <p>
+          Diving O Club est une plateforme de gestion destinée aux clubs de plongée
+          associatifs et à leurs membres : gestion du profil, des adhésions, des
+          certificats médicaux et des inscriptions aux événements.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="2. Accès au service et compte">
+        <p>
+          L&apos;accès aux fonctionnalités réservées nécessite la création d&apos;un
+          compte. Vous vous engagez à fournir des informations exactes et à maintenir
+          la confidentialité de vos identifiants. Vous êtes responsable des activités
+          réalisées depuis votre compte.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="3. Obligations de l'utilisateur">
+        <p>Vous vous engagez à ne pas :</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>usurper l&apos;identité d&apos;un tiers ou fournir de fausses informations ;</li>
+          <li>déposer des contenus illicites, trompeurs ou portant atteinte aux droits d&apos;autrui ;</li>
+          <li>tenter de perturber le fonctionnement ou la sécurité de la plateforme.</li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection title="4. Contenus déposés">
+        <p>
+          Vous restez responsable des documents que vous déposez (notamment le
+          certificat médical et la photo de profil) et garantissez disposer du droit
+          de les transmettre. Ces contenus ne sont utilisés que dans le cadre des
+          finalités décrites dans la{' '}
+          <Link
+            href="/confidentialite"
+            className="text-[#3DA9FC] underline underline-offset-2 hover:text-[#0d3b66] transition"
+          >
+            politique de confidentialité
+          </Link>
+          .
+        </p>
+      </LegalSection>
+
+      <LegalSection title="5. Disponibilité et responsabilité">
+        <p>
+          La plateforme est en cours de construction et en constante évolution :
+          de nouvelles fonctionnalités et améliorations sont régulièrement déployées,
+          en restant attentif aux retours des utilisateurs. À ce titre, elle est
+          fournie « en l&apos;état », sans garantie de disponibilité continue, et
+          l&apos;éditeur ne saurait être tenu responsable des interruptions de service
+          ou des dommages indirects résultant de l&apos;utilisation du site.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="6. Données personnelles">
+        <p>
+          Le traitement de vos données est décrit dans la{' '}
+          <Link
+            href="/confidentialite"
+            className="text-[#3DA9FC] underline underline-offset-2 hover:text-[#0d3b66] transition"
+          >
+            politique de confidentialité
+          </Link>
+          . Vous pouvez à tout moment télécharger ou supprimer vos données depuis votre
+          espace profil.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="7. Évolution des CGU">
+        <p>
+          Les présentes CGU peuvent être modifiées pour suivre l&apos;évolution de la
+          plateforme ou de la réglementation. La version applicable est celle publiée
+          sur cette page.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="8. Droit applicable">
+        <p>
+          Les présentes CGU sont soumises au droit français. À défaut de résolution
+          amiable, tout litige relève de la compétence des tribunaux français.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/app/frontend/app/components/layout/Footer.tsx
+++ b/app/frontend/app/components/layout/Footer.tsx
@@ -8,8 +8,8 @@ export default function Footer() {
     <footer className="bg-[#0d3b66] text-white px-6 py-12 md:px-16">
       <div className="max-w-7xl mx-auto">
 
-        {/* 3 columns */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-10 mb-10">
+        {/* 2 columns */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-10">
 
           {/* 1st column - Logo + description */}
           <div>
@@ -33,22 +33,16 @@ export default function Footer() {
             </ul>
           </div>
 
-          {/* 3rd column - Information */}
-          <div>
-            <h3 className="font-bold text-lg mb-4">Informations</h3>
-            <p className="text-[#48cae4] text-sm leading-relaxed mb-4">
-              Application web pour la gestion d&apos;adhésions, événements et certificats médicaux.
-            </p>
-            <p className="text-[#48cae4] text-sm">
-              Version 1.0 - Avril 2026
-            </p>
-          </div>
-
         </div>
 
         {/* Separator + copyright */}
-        <div className="border-t border-white/20 pt-6 text-center text-[#48cae4] text-sm">
-          © {currentYear} Diving O Club. Tous droits réservés.
+        <div className="border-t border-white/20 pt-6 flex flex-col sm:flex-row items-center justify-between gap-3 text-[#48cae4] text-sm">
+          <p>© {currentYear} Diving O Club. Tous droits réservés.</p>
+          <nav className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
+            <Link href="/confidentialite" className="hover:text-white transition-colors">Confidentialité</Link>
+            <Link href="/mentions-legales" className="hover:text-white transition-colors">Mentions légales</Link>
+            <Link href="/cgu" className="hover:text-white transition-colors">CGU</Link>
+          </nav>
         </div>
 
       </div>

--- a/app/frontend/app/components/legal/LegalPage.tsx
+++ b/app/frontend/app/components/legal/LegalPage.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from 'react';
+
+type LegalPageProps = {
+  title: string;
+  updatedAt: string;
+  intro?: ReactNode;
+  children: ReactNode;
+};
+
+// Shared chrome for static legal pages (privacy policy, legal notice, terms):
+// gradient background, centered readable column, header with last-updated date.
+export default function LegalPage({ title, updatedAt, intro, children }: LegalPageProps) {
+  return (
+    <div className="min-h-screen bg-linear-to-b from-[#e8f4ff] to-white">
+      <div className="max-w-3xl mx-auto px-4 py-12 sm:py-16">
+        <header className="mb-10">
+          <h1 className="text-3xl sm:text-4xl font-bold text-[#0d3b66] mb-3">{title}</h1>
+          <p className="text-sm text-gray-400">Dernière mise à jour : {updatedAt}</p>
+          {intro && <div className="mt-4 text-[#006994] leading-relaxed">{intro}</div>}
+        </header>
+        <div className="space-y-6">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+type LegalSectionProps = {
+  title: string;
+  children: ReactNode;
+};
+
+// A single titled card within a legal page.
+export function LegalSection({ title, children }: LegalSectionProps) {
+  return (
+    <section className="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 sm:p-8">
+      <h2 className="text-lg font-semibold text-[#0d3b66] mb-3">{title}</h2>
+      <div className="text-sm text-gray-600 leading-relaxed space-y-3">{children}</div>
+    </section>
+  );
+}

--- a/app/frontend/app/components/profile/DeleteAccountModal.tsx
+++ b/app/frontend/app/components/profile/DeleteAccountModal.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useState } from 'react'
+import { Trash2, X, Download } from 'lucide-react'
+
+type Props = {
+  onClose: () => void
+  onConfirm: () => void
+  onDownload: () => void
+  loading: boolean
+}
+
+export function DeleteAccountModal({ onClose, onConfirm, onDownload, loading }: Props) {
+  const [step, setStep] = useState<1 | 2>(1)
+  const [confirmed, setConfirmed] = useState(false)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm px-4"
+      onClick={(e) => { if (e.target === e.currentTarget && !loading) onClose() }}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 flex flex-col gap-5">
+
+        <div className="flex items-center justify-between">
+          <div className="w-10 h-10 bg-red-100 rounded-xl flex items-center justify-center">
+            <Trash2 className="w-5 h-5 text-red-500" />
+          </div>
+          <button
+            onClick={onClose}
+            disabled={loading}
+            aria-label="Fermer"
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-xl transition-colors disabled:opacity-50"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div>
+          <h2 className="text-lg font-bold text-[#0d3b66] mb-2">Supprimer mon compte</h2>
+          {step === 1 ? (
+            <p className="text-sm text-gray-500 leading-relaxed">
+              Cette action est définitive. Vos informations personnelles (identité,
+              coordonnées, profil de plongée) ainsi que vos certificats médicaux seront
+              supprimés. Vos adhésions et inscriptions resteront enregistrées dans les
+              clubs concernés, mais dissociées de votre identité.
+            </p>
+          ) : (
+            <p className="text-sm text-gray-500 leading-relaxed">
+              Dernière étape : confirmez la suppression définitive de votre compte.
+            </p>
+          )}
+        </div>
+
+        {step === 1 && (
+          <button
+            onClick={onDownload}
+            className="flex items-center justify-center gap-2 rounded-lg border border-[#3DA9FC] bg-[#e8f4ff] px-5 py-2.5 text-sm font-medium text-[#0D3B66] hover:bg-[#d0eaff] transition"
+          >
+            <Download className="w-4 h-4" />
+            Télécharger mes données avant de partir
+          </button>
+        )}
+
+        {step === 2 && (
+          <label className="flex items-start gap-3 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={confirmed}
+              onChange={(e) => setConfirmed(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-500 focus:ring-red-400"
+            />
+            <span>Je comprends que cette action est irréversible.</span>
+          </label>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            onClick={step === 1 ? onClose : () => setStep(1)}
+            disabled={loading}
+            className="flex-1 py-2.5 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors disabled:opacity-50"
+          >
+            {step === 1 ? 'Annuler' : 'Retour'}
+          </button>
+          {step === 1 ? (
+            <button
+              onClick={() => setStep(2)}
+              className="flex-1 py-2.5 rounded-xl bg-red-500 text-white text-sm font-medium hover:bg-red-600 transition-colors"
+            >
+              Continuer
+            </button>
+          ) : (
+            <button
+              onClick={onConfirm}
+              disabled={!confirmed || loading}
+              className="flex-1 py-2.5 rounded-xl bg-red-500 text-white text-sm font-medium hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Suppression...' : 'Supprimer définitivement mon compte'}
+            </button>
+          )}
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/app/confidentialite/page.tsx
+++ b/app/frontend/app/confidentialite/page.tsx
@@ -1,0 +1,143 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import LegalPage, { LegalSection } from '../components/legal/LegalPage';
+
+export const metadata: Metadata = {
+  title: 'Politique de confidentialité — Diving O Club',
+  description:
+    'Données personnelles collectées par Diving O Club, durées de conservation et exercice de vos droits RGPD.',
+};
+
+export default function ConfidentialitePage() {
+  return (
+    <LegalPage
+      title="Politique de confidentialité"
+      updatedAt="24 juin 2026"
+      intro={
+        <p>
+          Cette politique décrit les données personnelles traitées par Diving O Club,
+          les raisons de leur collecte, leur durée de conservation et les droits dont
+          vous disposez conformément au Règlement Général sur la Protection des
+          Données (RGPD).
+        </p>
+      }
+    >
+      <LegalSection title="1. Responsable du traitement">
+        <p>
+          Le site Diving O Club est édité par Kevin Lavier. Pour toute question relative à vos données
+          personnelles, vous pouvez écrire à :{' '}
+          <span className="font-medium text-[#0d3b66]">
+            divingoclub@gmail.com
+          </span>
+          .
+        </p>
+      </LegalSection>
+
+      <LegalSection title="2. Données que nous collectons">
+        <p>Dans le cadre de l&apos;utilisation de la plateforme, nous collectons :</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>
+            <strong>Identité :</strong> nom, prénom, adresse e-mail, numéro de
+            téléphone, date de naissance, adresse postale (rue, code postal, ville).
+          </li>
+          <li>
+            <strong>Compte :</strong> mot de passe, stocké uniquement sous forme
+            chiffrée (haché) et jamais en clair.
+          </li>
+          <li>
+            <strong>Données de plongée :</strong> numéro de licence FFESSM, niveau de
+            plongée, niveau d&apos;encadrement.
+          </li>
+          <li>
+            <strong>Vie associative :</strong> adhésions à des clubs, rôles et
+            inscriptions aux événements.
+          </li>
+        </ul>
+        <p>
+          Nous ne collectons aucune donnée bancaire ou de paiement, et ne pratiquons
+          aucune publicité ciblée.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="3. Durées de conservation">
+        <ul className="list-disc pl-5 space-y-1">
+          <li>
+            <strong>Données du compte et de profil :</strong> conservées tant que
+            votre compte est actif, puis anonymisées lors de sa suppression.
+          </li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection title="4. Destinataires des données">
+        <p>
+          Vos données ne sont ni vendues ni cédées. Elles sont accessibles à
+          l&apos;éditeur du site (administration de la plateforme) et aux responsables
+          du club auquel vous adhérez, pour la gestion de votre adhésion. Elles sont
+          hébergées par notre prestataire technique (voir les{' '}
+          <Link
+            href="/mentions-legales"
+            className="text-[#3DA9FC] underline underline-offset-2 hover:text-[#0d3b66] transition"
+          >
+            mentions légales
+          </Link>
+          ). Aucun transfert n&apos;est réalisé en dehors de l&apos;Union européenne.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="5. Cookies">
+        <p>
+          La plateforme utilise un seul cookie strictement nécessaire à son
+          fonctionnement : un cookie d&apos;authentification (sécurisé, non accessible
+          au code JavaScript) qui maintient votre session après connexion. Aucun
+          cookie publicitaire ou de mesure d&apos;audience n&apos;est déposé.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="6. Vos droits">
+        <p>Conformément au RGPD, vous disposez des droits suivants :</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>droit d&apos;accès et de rectification de vos données ;</li>
+          <li>droit à l&apos;effacement (suppression de votre compte) ;</li>
+          <li>droit à la portabilité (export de vos données au format JSON) ;</li>
+          <li>droit d&apos;opposition et de limitation du traitement.</li>
+        </ul>
+        <p>
+          Vous pouvez exercer la plupart de ces droits directement depuis votre{' '}
+          <Link
+            href="/profile"
+            className="text-[#3DA9FC] underline underline-offset-2 hover:text-[#0d3b66] transition"
+          >
+            espace profil
+          </Link>{' '}
+          : modification de vos informations, téléchargement de vos données et
+          suppression de votre compte. Pour toute autre demande, contactez
+          l&apos;éditeur à l&apos;adresse indiquée en section 1.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="7. Sécurité">
+        <p>
+          Les mots de passe sont chiffrés (hachés) et les échanges avec la plateforme
+          sont sécurisés. Nous mettons en œuvre des mesures techniques raisonnables
+          pour protéger vos données contre tout accès non autorisé.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="8. Réclamation">
+        <p>
+          Si vous estimez que vos droits ne sont pas respectés, vous pouvez introduire
+          une réclamation auprès de la Commission Nationale de l&apos;Informatique et
+          des Libertés (CNIL). {' '}
+          <a
+            href="https://www.cnil.fr"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#3DA9FC] underline underline-offset-2 hover:text-[#0d3b66] transition"
+          >
+            www.cnil.fr
+          </a>
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/app/frontend/app/lib/api/user.ts
+++ b/app/frontend/app/lib/api/user.ts
@@ -57,3 +57,15 @@ export async function exportMyData(): Promise<Blob | null> {
     return null;
   }
 }
+
+export async function deleteAccount(): Promise<boolean> {
+  try {
+    const res = await clientFetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/app/frontend/app/mentions-legales/page.tsx
+++ b/app/frontend/app/mentions-legales/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import LegalPage, { LegalSection } from '../components/legal/LegalPage';
+
+export const metadata: Metadata = {
+  title: 'Mentions légales — Diving O Club',
+  description: 'Informations légales relatives à l’éditeur et à l’hébergeur du site Diving O Club.',
+};
+
+export default function MentionsLegalesPage() {
+  return (
+    <LegalPage title="Mentions légales" updatedAt="24 juin 2026">
+      <LegalSection title="Éditeur du site">
+        <p>
+          Le site Diving O Club est édité par{' '}
+          <strong>Kevin Lavier</strong>.
+        </p>
+        <p>
+          Contact :{' '}
+          <span className="font-medium text-[#0d3b66]">
+            divingoclub@gmail.com
+          </span>
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Hébergeur">
+        <p>
+          Le site est hébergé par{' '}
+          <span className="font-medium text-[#0d3b66]">Amazon Web Services EMEA SARL</span>,
+          38 avenue John F. Kennedy, L-1855 Luxembourg.
+        </p>
+        <p>
+          Les données sont stockées dans la région AWS Europe (Paris), située en
+          France, au sein de l&apos;Union européenne.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Propriété intellectuelle">
+        <p>
+          L&apos;ensemble des éléments du site (structure, textes, logo, interface)
+          est protégé par le droit de la propriété intellectuelle. Toute reproduction
+          ou réutilisation sans autorisation préalable est interdite.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Données personnelles">
+        <p>
+          Le traitement de vos données personnelles est décrit dans notre{' '}
+          <Link
+            href="/confidentialite"
+            className="text-[#3DA9FC] underline underline-offset-2 hover:text-[#0d3b66] transition"
+          >
+            politique de confidentialité
+          </Link>
+          .
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/app/frontend/app/profile/page.tsx
+++ b/app/frontend/app/profile/page.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '../context/AuthContext'
-import { getMe, updateMe, exportMyData } from '@/app/lib/api/user'
+import { getMe, updateMe, exportMyData, deleteAccount } from '@/app/lib/api/user'
 import { ChangePasswordModal } from '@/app/components/profile/ChangePasswordModal'
+import { DeleteAccountModal } from '@/app/components/profile/DeleteAccountModal'
 import { User } from '@/app/types/user'
 import { UpdateUserDto } from '@/app/types/user'
 import { PersonalInfoSection } from '@/app/components/profile/PersonalInfoSection'
@@ -39,7 +40,7 @@ function parseBirthDate(dateStr: string | null): { day: string; month: string; y
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function ProfilePage() {
-  const { user: authUser, loading } = useAuth()
+  const { user: authUser, loading, logout } = useAuth()
   const router = useRouter()
 
   const [profile, setProfile] = useState<User | null>(null)
@@ -51,6 +52,8 @@ export default function ProfilePage() {
   const [isSaving, setIsSaving] = useState(false)
   const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
   const [showPasswordModal, setShowPasswordModal] = useState(false)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [navHeight, setNavHeight] = useState(68)
 
   useEffect(() => {
@@ -216,7 +219,20 @@ export default function ProfilePage() {
   }
 
   function handleDeleteRequest() {
-    // TODO : open the deletion modal
+    setShowDeleteModal(true)
+  }
+
+  async function handleConfirmDelete() {
+    setIsDeleting(true)
+    const ok = await deleteAccount()
+    if (!ok) {
+      setIsDeleting(false)
+      showToast('error', 'La suppression a échoué. Veuillez réessayer.')
+      return
+    }
+    // The backend already cleared the session cookie; sync the client state.
+    logout()
+    router.push('/')
   }
 
   // ─── Loading states ───────────────────────────────────────────────────
@@ -350,6 +366,15 @@ export default function ProfilePage() {
             setShowPasswordModal(false)
             showToast('success', 'Profil mis à jour avec succès')
           }}
+        />
+      )}
+
+      {showDeleteModal && (
+        <DeleteAccountModal
+          onClose={() => setShowDeleteModal(false)}
+          onConfirm={handleConfirmDelete}
+          onDownload={handleDownload}
+          loading={isDeleting}
         />
       )}
     </div>

--- a/app/frontend/app/register/page.tsx
+++ b/app/frontend/app/register/page.tsx
@@ -105,9 +105,9 @@ export default function RegisterPage() {
 
             <p className="text-center text-xs text-gray-400">
               En créant un compte, vous acceptez nos{' '}
-              <span className="text-[#006994] cursor-pointer hover:underline">conditions d&apos;utilisation</span>
+              <Link href="/cgu" className="text-[#006994] cursor-pointer hover:underline">conditions d&apos;utilisation</Link>
               {' '}et notre{' '}
-              <span className="text-[#006994] cursor-pointer hover:underline">politique de confidentialité</span>.
+              <Link href="/confidentialite" className="text-[#006994] cursor-pointer hover:underline">politique de confidentialité</Link>.
             </p>
 
           </form>


### PR DESCRIPTION
- Legal pages: Privacy Policy (/confidentialite), Legal Notice (/mentions-legales), Terms (/cgu) via a shared
  LegalPage component; linked from footer + register. Content matches current scope (no payments/logs).
  - Data export: GET /auth/me/export — JSON of the user's data (excludes password hash).
  - Account deletion: DELETE /auth/me — anonymize fields, delete medical certificates, soft delete, clear cookie.
  Frontend DeleteAccountModal (2 steps) → logout → redirect.
  - Fixes: soft-deleted users no longer crash member/participant lists (an admin had lost club access), no longer
  count toward event capacity or waitlist promotion. Also: public GET /clubs/:slug no longer leaks password
  hashes.

  Notes

  - firstName/lastName anonymized to a marker, not null (NOT NULL columns; no migration needed — deleted_at
  already in schema).
  - Certificate files (storage) not yet removed, only DB rows.