### PR TITLE
fix(ci): make staging schema reset deterministic on deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -81,11 +81,13 @@ jobs:
             echo "⏳ Waiting for services to be healthy..."
             sleep 15
 
-            echo "🗄️ Running migrations..."
+            echo "🗄️ Resetting the schema (staging is reseeded on every deploy)..."
+            sudo docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T postgres-staging psql -U diving_admin -d diving_o_club_staging -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+
+            echo "🗄️ Running migrations (recreates the schema from scratch)..."
             sudo docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T backend-staging npm run migration:run
 
-            echo "🌱 Resetting and seeding database..."
-            sudo docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T postgres-staging psql -U diving_admin -d diving_o_club_staging -c "TRUNCATE role, club, app_user, membership, event RESTART IDENTITY CASCADE;" || echo "⚠️ Tables may not exist yet"
+            echo "🌱 Seeding database..."
             sudo docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T backend-staging npm run seed
 
             echo "📊 STAGING Services status:"

--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -27,7 +27,7 @@
     "migration:run:test": "DOTENV_CONFIG_PATH=.env.test npm run migration:run",
     "seed:test": "DOTENV_CONFIG_PATH=.env.test npm run seed",
     "db:test:setup": "npm run migration:run:test && npm run seed:test",
-    "db:reset": "set -a && . ./.env && set +a && PGPASSWORD=\"$STAGING_DB_PASSWORD\" psql -h localhost -p 15433 -U diving_admin -d diving_o_club_staging -c 'TRUNCATE role, club, app_user, membership, event RESTART IDENTITY CASCADE;' && npm run seed"
+    "db:reset": "set -a && . ./.env && set +a && PGPASSWORD=\"$STAGING_DB_PASSWORD\" psql -h localhost -p 15433 -U diving_admin -d diving_o_club_staging -c 'TRUNCATE roles, clubs, users, memberships, events, registrations, certificates, payments RESTART IDENTITY CASCADE;' && npm run seed"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",


### PR DESCRIPTION
GDPR feature set (legal pages, data export, account deletion), fixes for
  soft-deleted users breaking club/event reads, and a staging deploy fix.

  ## Changes
  - **Legal pages:** Privacy Policy (`/confidentialite`), Legal Notice
    (`/mentions-legales`), Terms (`/cgu`) via a shared `LegalPage` component;
    linked from footer + register. Content matches current scope (no payments/logs).
  - **Data export:** `GET /auth/me/export` — JSON of the user's data (no password hash).
  - **Account deletion:** `DELETE /auth/me` — anonymize fields, delete medical
    certificates, soft delete, clear cookie. Frontend `DeleteAccountModal` (2 steps)
    → logout → redirect.
  - **Fixes (soft-deleted users):** no longer crash member/participant lists (an
    admin had lost club access), no longer count toward event capacity or waitlist
    promotion. Public `GET /clubs/:slug` no longer leaks password hashes.
  - **CI/CD:** staging deploy now resets the schema before migrations (fixes a
    migration/schema drift causing login 500); removed a broken redundant TRUNCATE.

  ## Notes
  - `firstName`/`lastName` anonymized to a marker, not `null` (NOT NULL columns;
    no migration needed — `deleted_at` already in schema).
  - Certificate files (storage) not yet removed, only DB rows.
  - Prod deploy untouched (no schema reset — real data).