### PR TITLE
feat(auth): block account deletion for a club's admin when there is only 1 admin

### DIFF
--- a/app/backend/src/auth/auth.controller.ts
+++ b/app/backend/src/auth/auth.controller.ts
@@ -95,7 +95,9 @@ export class AuthController {
   @Delete('me')
   @UseGuards(AuthGuard('jwt'))
   @ApiCookieAuth()
-  @ApiOperation({ summary: 'Delete the current account (GDPR right to erasure)' })
+  @ApiOperation({
+    summary: 'Delete the current account (GDPR right to erasure)',
+  })
   @ApiResponse({
     status: 200,
     description: 'Account anonymized and deleted; the cookie is cleared.',

--- a/app/backend/src/auth/auth.service.spec.ts
+++ b/app/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Response } from 'express';
+import { AuthService } from './auth.service';
+import { User } from '../user/user.entity';
+import { Membership } from '../membership/membership.entity';
+import { EventRegistration } from '../event/event-registration.entity';
+import { Certificate } from '../certificate/certificate.entity';
+import { LogService } from '../log/log.service';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const mockUserRepo = {
+  update: jest.fn(),
+  softDelete: jest.fn(),
+};
+
+// Query builder used by deleteMe to count the other active admins of a club.
+const mockMembershipQB = {
+  innerJoin: jest.fn(),
+  where: jest.fn(),
+  andWhere: jest.fn(),
+  getCount: jest.fn(),
+};
+const mockMembershipRepo = {
+  find: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+// Query builder used by deleteMe to delete the user's certificates.
+const mockCertificateQB = {
+  delete: jest.fn(),
+  where: jest.fn(),
+  execute: jest.fn(),
+};
+const mockCertificateRepo = {
+  createQueryBuilder: jest.fn(),
+};
+
+const mockRegistrationRepo = {};
+const mockJwtService = { sign: jest.fn() };
+const mockLogService = {
+  logAuth: jest.fn(),
+  logMembership: jest.fn(),
+  logError: jest.fn(),
+};
+
+const makeRes = () => {
+  const clearCookie = jest.fn();
+  return { res: { clearCookie } as unknown as Response, clearCookie };
+};
+
+// ── Suite ──────────────────────────────────────────────────────────────────
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        {
+          provide: getRepositoryToken(Membership),
+          useValue: mockMembershipRepo,
+        },
+        {
+          provide: getRepositoryToken(EventRegistration),
+          useValue: mockRegistrationRepo,
+        },
+        {
+          provide: getRepositoryToken(Certificate),
+          useValue: mockCertificateRepo,
+        },
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: LogService, useValue: mockLogService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    jest.clearAllMocks();
+
+    // Re-wire the chainable query builders after the reset.
+    mockMembershipQB.innerJoin.mockReturnThis();
+    mockMembershipQB.where.mockReturnThis();
+    mockMembershipQB.andWhere.mockReturnThis();
+    mockMembershipRepo.createQueryBuilder.mockReturnValue(mockMembershipQB);
+
+    mockCertificateQB.delete.mockReturnThis();
+    mockCertificateQB.where.mockReturnThis();
+    mockCertificateQB.execute.mockResolvedValue({});
+    mockCertificateRepo.createQueryBuilder.mockReturnValue(mockCertificateQB);
+  });
+
+  describe('deleteMe', () => {
+    it('blocks deletion when the user is the only admin of a club', async () => {
+      mockMembershipRepo.find.mockResolvedValue([
+        { idMembership: 1, club: { idClub: 5, name: 'Aquaclub21' } },
+      ]);
+      mockMembershipQB.getCount.mockResolvedValue(0); // no other admin left
+
+      await expect(service.deleteMe(1, makeRes().res)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(mockUserRepo.update).not.toHaveBeenCalled();
+      expect(mockUserRepo.softDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes the account when another admin remains in the club', async () => {
+      mockMembershipRepo.find.mockResolvedValue([
+        { idMembership: 1, club: { idClub: 5, name: 'Aquaclub21' } },
+      ]);
+      mockMembershipQB.getCount.mockResolvedValue(1); // another admin exists
+      const { res, clearCookie } = makeRes();
+
+      const result = await service.deleteMe(1, res);
+
+      expect(result.message).toBe('Compte supprimé');
+      expect(mockUserRepo.update).toHaveBeenCalledTimes(1);
+      expect(mockUserRepo.softDelete).toHaveBeenCalledWith(1);
+      expect(clearCookie).toHaveBeenCalledWith('access_token');
+    });
+
+    it('deletes the account when the user is not an admin of any club', async () => {
+      mockMembershipRepo.find.mockResolvedValue([]);
+      const { res, clearCookie } = makeRes();
+
+      await service.deleteMe(2, res);
+
+      expect(mockMembershipRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(mockUserRepo.softDelete).toHaveBeenCalledWith(2);
+      expect(clearCookie).toHaveBeenCalledWith('access_token');
+    });
+  });
+});

--- a/app/backend/src/auth/auth.service.ts
+++ b/app/backend/src/auth/auth.service.ts
@@ -5,7 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { Response } from 'express';
 import * as argon2 from 'argon2';
@@ -166,10 +166,38 @@ export class AuthService {
    * the `RESTRICT` relations (memberships, registrations) intact for club data
    * integrity. The session cookie is cleared on the way out.
    */
-  async deleteMe(
-    userId: number,
-    res: Response,
-  ): Promise<{ message: string }> {
+  async deleteMe(userId: number, res: Response): Promise<{ message: string }> {
+    // Block deletion while the user is the only admin of a club: they must hand
+    // over admin rights first, otherwise the club would be left unmanageable.
+    const adminMemberships = await this.membershipRepo.find({
+      where: {
+        user: { idUser: userId },
+        status: 'active',
+        role: { codeRole: In(['admin', 'super_admin']) },
+      },
+      relations: { club: true },
+    });
+
+    for (const m of adminMemberships) {
+      const otherAdmins = await this.membershipRepo
+        .createQueryBuilder('m')
+        .innerJoin('m.user', 'u') // excludes soft-deleted accounts
+        .innerJoin('m.role', 'r')
+        .where('m.id_club = :clubId', { clubId: m.club.idClub })
+        .andWhere('m.status = :status', { status: 'active' })
+        .andWhere('r.code_role IN (:...roles)', {
+          roles: ['admin', 'super_admin'],
+        })
+        .andWhere('m.id_membership != :selfId', { selfId: m.idMembership })
+        .getCount();
+
+      if (otherAdmins === 0) {
+        throw new ConflictException(
+          `Vous êtes le seul administrateur du club « ${m.club.name} ». Désignez un autre administrateur avant de supprimer votre compte.`,
+        );
+      }
+    }
+
     await this.userRepo.update(userId, {
       email: `deleted_${userId}@deleted.local`,
       firstName: 'Compte',

--- a/app/backend/src/log/log.service.ts
+++ b/app/backend/src/log/log.service.ts
@@ -14,17 +14,18 @@ export class LogService {
   private readonly logger = new Logger(LogService.name);
 
   /** Record an authentication event (register, login success/failure, logout). */
-  async logAuth(data: {
+  logAuth(data: {
     action: string;
     userId?: number;
     email?: string;
     ip?: string;
   }): Promise<void> {
     this.logger.log(`auth ${JSON.stringify(data)}`);
+    return Promise.resolve();
   }
 
   /** Record a membership or event action (request, role change, registration…). */
-  async logMembership(data: {
+  logMembership(data: {
     action: string;
     actorId?: number;
     targetUserId?: number;
@@ -32,15 +33,17 @@ export class LogService {
     clubName?: string;
   }): Promise<void> {
     this.logger.log(`membership ${JSON.stringify(data)}`);
+    return Promise.resolve();
   }
 
   /** Record a handled error (status code, endpoint, message). */
-  async logError(data: {
+  logError(data: {
     statusCode: number;
     endpoint: string;
     message: string;
     userId?: number;
   }): Promise<void> {
     this.logger.log(`error ${JSON.stringify(data)}`);
+    return Promise.resolve();
   }
 }

--- a/app/frontend/app/lib/api/user.ts
+++ b/app/frontend/app/lib/api/user.ts
@@ -58,14 +58,16 @@ export async function exportMyData(): Promise<Blob | null> {
   }
 }
 
-export async function deleteAccount(): Promise<boolean> {
+export async function deleteAccount(): Promise<{ ok: boolean; message?: string }> {
   try {
     const res = await clientFetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, {
       method: 'DELETE',
       credentials: 'include',
     });
-    return res.ok;
+    if (res.ok) return { ok: true };
+    const body = await res.json().catch(() => null);
+    return { ok: false, message: body?.message };
   } catch {
-    return false;
+    return { ok: false };
   }
 }

--- a/app/frontend/app/profile/page.tsx
+++ b/app/frontend/app/profile/page.tsx
@@ -224,10 +224,11 @@ export default function ProfilePage() {
 
   async function handleConfirmDelete() {
     setIsDeleting(true)
-    const ok = await deleteAccount()
-    if (!ok) {
+    const result = await deleteAccount()
+    if (!result.ok) {
       setIsDeleting(false)
-      showToast('error', 'La suppression a échoué. Veuillez réessayer.')
+      setShowDeleteModal(false)
+      showToast('error', result.message ?? 'La suppression a échoué. Veuillez réessayer.')
       return
     }
     // The backend already cleared the session cookie; sync the client state.


### PR DESCRIPTION
Reject account deletion when the user is the only active admin of a club
  (409 with a clear message); they must assign another admin first. Surface
  the message in the delete modal and add AuthService unit tests for the guard.
  Also drop the now-unused `async` on LogService methods (eslint require-await).